### PR TITLE
feat(edge): configurable discovery HTTP timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,15 +231,16 @@ npm test
 
 ## Integration & Customisation
 
-- **Edge Agent** – integrates with EDR/XDR and vulnerability scanner APIs when
-  environment variables such as `EDR_API_URL`, `EDR_API_TOKEN`,
-  `NESSUS_API_URL` and `NESSUS_API_TOKEN` are provided. When these are
-  undefined and `EDGE_SELF_DISCOVERY=true`, the agent falls back to
-  self‑managed discovery using `psutil` and optional `osquery`. Use
-  `DISCOVERY_INTERVAL_SECONDS` to control how often an `AssetEvent` is
-  published and `EDGE_TENANT_ID` to tag events. Disable local discovery by
-  setting `EDGE_SELF_DISCOVERY=false` and rely solely on vendor APIs. Example
-  configuration:
+  - **Edge Agent** – integrates with EDR/XDR and vulnerability scanner APIs when
+    environment variables such as `EDR_API_URL`, `EDR_API_TOKEN`,
+    `NESSUS_API_URL` and `NESSUS_API_TOKEN` are provided. When these are
+    undefined and `EDGE_SELF_DISCOVERY=true`, the agent falls back to
+    self‑managed discovery using `psutil` and optional `osquery`. Use
+    `DISCOVERY_INTERVAL_SECONDS` to control how often an `AssetEvent` is
+    published and `EDGE_TENANT_ID` to tag events. `DISCOVERY_HTTP_TIMEOUT`
+    controls the timeout for API calls (default 5s). Disable local discovery by
+    setting `EDGE_SELF_DISCOVERY=false` and rely solely on vendor APIs. Example
+    configuration:
 
   ```bash
   # self-managed discovery

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -53,6 +53,7 @@ services:
       KAFKA_BOOTSTRAP: redpanda:9092
       EDGE_SELF_DISCOVERY: "true"
       DISCOVERY_INTERVAL_SECONDS: "3600"
+      DISCOVERY_HTTP_TIMEOUT: "5"
       EDGE_TENANT_ID: "local"
       EDR_API_URL: ""
       EDR_API_TOKEN: ""

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -23,12 +23,13 @@ Kafka.
 | `audit.events` | `edge_agent`, `infra_builder`, `rt_script_gen`, `rule_factory`, `deployer` | `mgmt_api` |
 
 ## Integration Points and Configuration
-- **Edge Agent** – integrates with EDR/XDR and scanner APIs when provided with
-  `EDR_API_URL`, `EDR_API_TOKEN`, `NESSUS_API_URL` and `NESSUS_API_TOKEN`. If
-  these are absent and `EDGE_SELF_DISCOVERY=true` the agent runs periodic
-  self-managed discovery using `psutil`, local utilities and optional
-  `osquery`. Discovery frequency and tenant tagging are controlled via
-  `DISCOVERY_INTERVAL_SECONDS` and `EDGE_TENANT_ID`.
+  - **Edge Agent** – integrates with EDR/XDR and scanner APIs when provided with
+    `EDR_API_URL`, `EDR_API_TOKEN`, `NESSUS_API_URL` and `NESSUS_API_TOKEN`. If
+    these are absent and `EDGE_SELF_DISCOVERY=true` the agent runs periodic
+    self-managed discovery using `psutil`, local utilities and optional
+    `osquery`. Discovery frequency and tenant tagging are controlled via
+    `DISCOVERY_INTERVAL_SECONDS` and `EDGE_TENANT_ID`; API requests use the
+    configurable `DISCOVERY_HTTP_TIMEOUT` (default 5s).
 - **Infra Builder** – replace the sample Terraform with custom templates and
   install a monitoring agent within each VM.
 - **RT Script Generator / Rule Factory** – connect these services to an LLM for

--- a/services/edge_agent/discovery.py
+++ b/services/edge_agent/discovery.py
@@ -13,6 +13,9 @@ import requests
 from .models import AssetEvent
 
 
+HTTP_TIMEOUT = float(os.getenv("DISCOVERY_HTTP_TIMEOUT", "5"))
+
+
 def collect_from_edr() -> dict | None:
     url = os.getenv("EDR_API_URL")
     if not url:
@@ -22,7 +25,7 @@ def collect_from_edr() -> dict | None:
     if token:
         headers["Authorization"] = f"Bearer {token}"
     try:
-        resp = requests.get(url, headers=headers, timeout=5)
+        resp = requests.get(url, headers=headers, timeout=HTTP_TIMEOUT)
         if resp.status_code != 200:
             return None
         data = resp.json()
@@ -44,7 +47,7 @@ def collect_from_scanner() -> dict | None:
     if token:
         headers["Authorization"] = f"Bearer {token}"
     try:
-        resp = requests.get(url, headers=headers, timeout=5)
+        resp = requests.get(url, headers=headers, timeout=HTTP_TIMEOUT)
         if resp.status_code != 200:
             return None
         data = resp.json()


### PR DESCRIPTION
## Summary
- allow discovery API calls to use configurable `DISCOVERY_HTTP_TIMEOUT`
- document edge agent discovery options and new timeout setting
- add the timeout variable to development `docker-compose`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689382796a34832d9064574a0a0bb75d