### PR TITLE
feat(edge_agent): add periodic asset discovery

### DIFF
--- a/services/edge_agent/main.py
+++ b/services/edge_agent/main.py
@@ -47,7 +47,7 @@ async def startup() -> None:
     interval = int(os.getenv("DISCOVERY_INTERVAL_SECONDS", "3600"))
 
     if enable_discovery:
-        async def periodic_discovery() -> None:
+        async def periodic_discovery():
             global producer
             while True:
                 try:
@@ -58,9 +58,7 @@ async def startup() -> None:
                     await producer.send_and_wait("asset.events", buffer.getvalue())
                 except Exception as exc:
                     import logging
-                    logging.exception(
-                        "Failed to collect or send asset event: %s", exc
-                    )
+                    logging.exception("Failed to collect or send asset event: %s", exc)
                 await asyncio.sleep(interval)
 
         asyncio.create_task(periodic_discovery())


### PR DESCRIPTION
## Summary
- run a periodic asset discovery task on startup

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689388bb62d8832d94b144e794ba2a55