### PR TITLE
docs: document edge agent discovery configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,9 +233,13 @@ npm test
 ## Integration & Customisation
 
   - **Edge Agent**
-    - Calls your EDR/XDR (`EDR_API_URL`, `EDR_API_TOKEN`) or Nessus (`NESSUS_API_URL`, `NESSUS_API_TOKEN`) if those variables are set.
-    - Falls back to self‑discovery when they are not set or fail.
-    - Uses `EDGE_SELF_DISCOVERY`, `DISCOVERY_INTERVAL_SECONDS` and `EDGE_TENANT_ID` to control periodic behaviour.
+    - Supports external EDR/XDR and Nessus integrations or self‑managed discovery when those APIs are unavailable.
+    - Configure using these environment variables:
+      - `EDGE_SELF_DISCOVERY`: set to `"true"` to enable local discovery when external integrations fail or are unset.
+      - `DISCOVERY_INTERVAL_SECONDS`: cadence for the periodic discovery task.
+      - `EDGE_TENANT_ID`: tag for emitted events.
+      - `EDR_API_URL` / `EDR_API_TOKEN`: optional endpoint and token for your EDR/XDR platform.
+      - `NESSUS_API_URL` / `NESSUS_API_TOKEN`: optional endpoint and token for Nessus.
 - **Infra Builder** – replace the sample Terraform with your own infrastructure
   templates and ensure a monitoring agent is installed in each lab VM.
 - **RT Script Generator** and **Rule Factory** – currently return stub outputs;

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -50,6 +50,7 @@ services:
       sh -c "pip install --no-cache-dir fastapi uvicorn[standard] aiokafka fastavro pydantic jinja2 psutil requests &&
              uvicorn services.edge_agent.main:app --host 0.0.0.0 --port 8200"
     environment:
+      # Discovery and integration settings
       KAFKA_BOOTSTRAP: redpanda:9092
       EDGE_SELF_DISCOVERY: "true"
       DISCOVERY_INTERVAL_SECONDS: "3600"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -23,19 +23,13 @@ Kafka.
 | `audit.events` | `edge_agent`, `infra_builder`, `rt_script_gen`, `rule_factory`, `deployer` | `mgmt_api` |
 
 ## Integration Points and Configuration
-  - **Edge Agent** – includes built-in periodic discovery. It polls EDR/XDR and
-    scanner APIs when `EDR_API_URL` or `NESSUS_API_URL` (and matching tokens)
-    are provided. If these variables are unset or calls fail and
-    `EDGE_SELF_DISCOVERY=true`, the agent performs local discovery using OS
-    tools. Configure the interval with `DISCOVERY_INTERVAL_SECONDS` and tag
-    events via `EDGE_TENANT_ID`.
-- **Infra Builder** – replace the sample Terraform with custom templates and
-  install a monitoring agent within each VM.
-- **RT Script Generator / Rule Factory** – connect these services to an LLM for
-  real script and rule generation.
-- **Deployer** – implement real API calls to your EDR/XDR and vulnerability
-  scanners. Configure with `EDR_URL`, `EDR_TOKEN`, `NESSUS_URL`,
-  `NESSUS_TOKEN`.
+
+| Component | Notes | Key Environment Variables |
+|-----------|-------|--------------------------|
+| **Edge Agent** | Periodic discovery task. Polls EDR/XDR (`EDR_API_URL`/`EDR_API_TOKEN`) or Nessus (`NESSUS_API_URL`/`NESSUS_API_TOKEN`) when configured; falls back to local discovery when `EDGE_SELF_DISCOVERY` is `true`. Interval controlled by `DISCOVERY_INTERVAL_SECONDS` and events tagged with `EDGE_TENANT_ID`. | `EDGE_SELF_DISCOVERY`, `DISCOVERY_INTERVAL_SECONDS`, `EDGE_TENANT_ID`, `EDR_API_URL`, `EDR_API_TOKEN`, `NESSUS_API_URL`, `NESSUS_API_TOKEN` |
+| **Infra Builder** | Replace the sample Terraform with custom templates and install a monitoring agent within each VM. | – |
+| **RT Script Generator / Rule Factory** | Connect these services to an LLM for real script and rule generation. | – |
+| **Deployer** | Implement real API calls to your EDR/XDR and vulnerability scanners. Configure with `EDR_URL`, `EDR_TOKEN`, `NESSUS_URL`, `NESSUS_TOKEN`. | `EDR_URL`, `EDR_TOKEN`, `NESSUS_URL`, `NESSUS_TOKEN` |
 
 ## Production Considerations
 Use a production-grade database such as Postgres instead of SQLite. Secure Kafka


### PR DESCRIPTION
## Summary
- clarify edge agent's periodic discovery and integration settings in docker-compose
- expand README to detail configuration of new discovery variables
- add architecture table row describing edge agent discovery task and env vars

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689475229d40832db4454b8f5b020fd0