### PR TITLE
feat: add minimal fastapi backend

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,0 +1,13 @@
+from pydantic_settings import BaseSettings
+
+class Settings(BaseSettings):
+    env: str = "dev"
+    api_host: str = "0.0.0.0"
+    api_port: int = 8000
+    db_dsn: str = "postgresql+psycopg://postgres:postgres@db:5432/catchattack"
+    cors_origins: list[str] = ["http://localhost:3000"]
+
+    class Config:
+        env_file = ".env"
+
+settings = Settings()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,8 @@
+from fastapi import FastAPI
+from .core.config import settings
+
+app = FastAPI(title="catchattack-beta API", version="0.1.0")
+
+@app.get("/api/v1/healthz")
+def healthz():
+    return {"status": "ok", "env": settings.env}


### PR DESCRIPTION
## Summary
- add FastAPI app and health check endpoint
- configure settings management with pydantic

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895b9c87cd4832dbd61c497095d558e