### PR TITLE
Add backend logging and DB session utilities

### DIFF
--- a/backend/app/core/logging.py
+++ b/backend/app/core/logging.py
@@ -1,0 +1,34 @@
+from logging.config import dictConfig
+
+LOGGING_CONFIG = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "default": {
+            "()": "uvicorn.logging.DefaultFormatter",
+            "fmt": "%(levelprefix)s %(message)s",
+            "use_colors": True,
+        },
+    },
+    "handlers": {
+        "default": {
+            "formatter": "default",
+            "class": "logging.StreamHandler",
+            "stream": "ext://sys.stdout",
+        },
+    },
+    "loggers": {
+        "uvicorn": {"handlers": ["default"], "level": "INFO"},
+        "uvicorn.error": {"handlers": ["default"], "level": "INFO"},
+        "uvicorn.access": {
+            "handlers": ["default"],
+            "level": "INFO",
+            "propagate": False,
+        },
+    },
+}
+
+
+def configure_logging() -> None:
+    """Configure application logging."""
+    dictConfig(LOGGING_CONFIG)

--- a/backend/app/db/__init__.py
+++ b/backend/app/db/__init__.py
@@ -1,0 +1,3 @@
+from .session import SessionLocal, engine
+
+__all__ = ["SessionLocal", "engine"]

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -1,0 +1,7 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from ..core.config import settings
+
+engine = create_engine(settings.db_dsn, pool_pre_ping=True)
+SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,0 +1,20 @@
+[project]
+name = "catchattack-backend"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = [
+  "fastapi>=0.111",
+  "uvicorn[standard]>=0.30",
+  "pydantic>=2.7",
+  "pydantic-settings>=2.3",
+  "SQLAlchemy>=2.0",
+  "psycopg[binary]>=3.2",
+  "alembic>=1.13",
+  "python-multipart>=0.0.9",
+]
+
+[tool.ruff]
+line-length = 100
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]


### PR DESCRIPTION
## Summary
- add uvicorn logging configuration helper
- set up SQLAlchemy engine and session
- introduce backend pyproject with dependencies and tooling config

## Testing
- `ruff check backend/app/core/logging.py backend/app/db/session.py backend/app/db/__init__.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895baa48318832db804141ab4acbfe8