### PR TITLE
Setup Alembic and minimal frontend

### DIFF
--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -1,0 +1,36 @@
+[alembic]
+script_location = app/db/migrations
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+propagate = 0
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+propagate = 0
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/backend/app/db/migrations/README
+++ b/backend/app/db/migrations/README
@@ -1,0 +1,1 @@
+This directory contains Alembic migration scripts.

--- a/backend/app/db/migrations/env.py
+++ b/backend/app/db/migrations/env.py
@@ -1,0 +1,42 @@
+from logging.config import fileConfig
+from sqlalchemy import create_engine, pool
+from alembic import context
+
+from app.core.config import settings
+
+config = context.config
+config.set_main_option("sqlalchemy.url", settings.db_dsn)
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = None
+
+
+def run_migrations_offline() -> None:
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    connectable = create_engine(settings.db_dsn, poolclass=pool.NullPool)
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/backend/app/db/migrations/script.py.mako
+++ b/backend/app/db/migrations/script.py.mako
@@ -1,0 +1,21 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+def upgrade() -> None:
+    pass
+
+def downgrade() -> None:
+    pass

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>catchattack-frontend</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "catchattack-frontend",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview --port 3000",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.5.4",
+    "vite": "^5.3.4",
+    "vitest": "^2.0.4"
+  }
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,5 @@
+export const API_BASE = import.meta.env.VITE_API_BASE ?? "http://localhost:8000";
+export async function ping() {
+  const r = await fetch(`${API_BASE}/api/v1/healthz`);
+  return r.json();
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,8 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+
+ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
+  <React.StrictMode>
+    <div>Hello catchattack-beta</div>
+  </React.StrictMode>
+);

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,0 +1,14 @@
+import { useEffect, useState } from "react";
+import { ping } from "../lib/api";
+
+export default function Dashboard() {
+  const [status, setStatus] = useState<string>("loading");
+
+  useEffect(() => {
+    ping()
+      .then((data) => setStatus(data.status ?? "unknown"))
+      .catch(() => setStatus("error"));
+  }, []);
+
+  return <div>status: {status}</div>;
+}


### PR DESCRIPTION
## Summary
- initialize Alembic migrations configured from settings
- add minimal Vite+React frontend with basic API client and dashboard

## Testing
- `pytest`
- `cd frontend && npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6895bb98bd74832da67ddccf7a8b9da7