### PR TITLE
Add Docker and docker-compose configurations

### DIFF
--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -1,0 +1,9 @@
+FROM python:3.11-slim
+WORKDIR /app
+ENV PIP_NO_CACHE_DIR=1
+COPY backend/pyproject.toml /app/backend/
+RUN pip install --upgrade pip && pip install -e /app/backend
+COPY backend /app/backend
+WORKDIR /app/backend
+EXPOSE 8000
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--proxy-headers"]

--- a/docker/Dockerfile.elastic
+++ b/docker/Dockerfile.elastic
@@ -1,0 +1,1 @@
+FROM docker.elastic.co/elasticsearch/elasticsearch:8.14.1

--- a/docker/Dockerfile.web
+++ b/docker/Dockerfile.web
@@ -1,0 +1,11 @@
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY frontend/package.json frontend/package-lock.json* frontend/pnpm-lock.yaml* ./
+RUN npm ci || npm i
+COPY frontend ./
+RUN npm run build
+
+FROM nginx:1.27-alpine
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 3000
+CMD ["nginx", "-g", "daemon off;"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,45 @@
+version: "3.9"
+services:
+  db:
+    image: postgres:16
+    environment:
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: catchattack
+    ports: ["5432:5432"]
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  api:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.api
+    environment:
+      ENV: dev
+      DB_DSN: postgresql+psycopg://postgres:postgres@db:5432/catchattack
+      CORS_ORIGINS: http://localhost:3000
+    depends_on:
+      db:
+        condition: service_healthy
+    ports: ["8000:8000"]
+
+  web:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.web
+    environment:
+      VITE_API_BASE: http://localhost:8000
+    depends_on:
+      - api
+    ports: ["3000:80"]
+
+  elastic:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.elastic
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+    ports: ["9200:9200"]


### PR DESCRIPTION
## Summary
- add API Dockerfile using python 3.11 and uvicorn entrypoint
- add web build with Node/Nginx and Elasticsearch Dockerfiles
- introduce docker-compose environment for db, api, web, elastic services

## Testing
- `npm test` *(fails: Missing script: "test")*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895bfca7c6c832d9836d94baaac2690