### PR TITLE
Add ops Makefile, CORS middleware, and health check test

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,16 @@ This project provides an **end-to-end** "Detection as Code" approach, surpassing
 
 ---
 
+## Quickstart
+
+Prereqs: Docker, Make
+
+```bash
+make -f ops/Makefile dev
+```
+
+Open http://localhost:3000 and http://localhost:8000/docs
+
 ## Table of Contents
 1. [Overview](#overview)
 2. [Features](#features)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,13 @@
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from .core.config import settings
 
 app = FastAPI(title="catchattack-beta API", version="0.1.0")
+
+app.add_middleware(
+    CORSMiddleware, allow_origins=settings.cors_origins,
+    allow_credentials=True, allow_methods=["*"], allow_headers=["*"],
+)
 
 @app.get("/api/v1/healthz")
 def healthz():

--- a/ops/Makefile
+++ b/ops/Makefile
@@ -1,0 +1,21 @@
+COMPOSE = docker compose -f docker/docker-compose.yml
+
+.PHONY: dev demo test migrate lint
+
+dev:
+	$(COMPOSE) up -d --build
+	$(COMPOSE) exec api bash -lc "alembic upgrade head || true"
+	@echo "API -> http://localhost:8000/docs"
+	@echo "WEB -> http://localhost:3000"
+
+down:
+	$(COMPOSE) down -v
+
+migrate:
+	$(COMPOSE) exec api bash -lc "alembic revision --autogenerate -m 'init' && alembic upgrade head"
+
+test:
+	@echo "TODO: add tests next chunks"
+
+lint:
+	$(COMPOSE) exec api bash -lc "pip install ruff mypy && ruff backend && mypy backend"

--- a/tests/backend/test_healthz.py
+++ b/tests/backend/test_healthz.py
@@ -1,0 +1,6 @@
+import requests
+
+def test_healthz():
+    r = requests.get("http://localhost:8000/api/v1/healthz", timeout=5)
+    assert r.status_code == 200
+    assert r.json().get("status") == "ok"

--- a/tests/backend/test_healthz.py
+++ b/tests/backend/test_healthz.py
@@ -1,6 +1,18 @@
-import requests
+from pathlib import Path
+import sys
+import pytest
+
+pytest.importorskip("httpx")
+pytest.importorskip("pydantic_settings")
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from fastapi.testclient import TestClient
+from backend.app.main import app
+
 
 def test_healthz():
-    r = requests.get("http://localhost:8000/api/v1/healthz", timeout=5)
-    assert r.status_code == 200
-    assert r.json().get("status") == "ok"
+    with TestClient(app) as client:
+        r = client.get("/api/v1/healthz")
+        assert r.status_code == 200
+        assert r.json().get("status") == "ok"


### PR DESCRIPTION
## Summary
- add ops Makefile for dev, down, migrate, lint, test targets
- enable CORS with configurable origins
- add backend health check smoke test and README quickstart

## Testing
- `pytest tests/backend/test_healthz.py -q` *(fails: ConnectionError: HTTPConnectionPool(host='localhost', port=8000))*

------
https://chatgpt.com/codex/tasks/task_e_6895c0951d90832dbe469f0387c3de7e