### PR TITLE
feat(db): add initial models and migrations

### DIFF
--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -1,5 +1,6 @@
 [alembic]
 script_location = app/db/migrations
+sqlalchemy.url = postgresql+psycopg://postgres:postgres@db:5432/catchattack
 
 [loggers]
 keys = root,sqlalchemy,alembic

--- a/backend/app/db/migrations/env.py
+++ b/backend/app/db/migrations/env.py
@@ -1,37 +1,40 @@
 from logging.config import fileConfig
-from sqlalchemy import create_engine, pool
-from alembic import context
+import os
 
-from app.core.config import settings
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+
+from app.db.models import Base
+
 
 config = context.config
-config.set_main_option("sqlalchemy.url", settings.db_dsn)
+
+# allow overriding URL via env var
+db_url = os.getenv("DB_DSN")
+if db_url:
+    config.set_main_option("sqlalchemy.url", db_url)
 
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
-target_metadata = None
+target_metadata = Base.metadata
 
 
 def run_migrations_offline() -> None:
     url = config.get_main_option("sqlalchemy.url")
-    context.configure(
-        url=url,
-        target_metadata=target_metadata,
-        literal_binds=True,
-        dialect_opts={"paramstyle": "named"},
-    )
-
+    context.configure(url=url, target_metadata=target_metadata, literal_binds=True)
     with context.begin_transaction():
         context.run_migrations()
 
 
 def run_migrations_online() -> None:
-    connectable = create_engine(settings.db_dsn, poolclass=pool.NullPool)
-
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
     with connectable.connect() as connection:
-        context.configure(connection=connection, target_metadata=target_metadata)
-
+        context.configure(connection=connection, target_metadata=target_metadata, compare_type=True)
         with context.begin_transaction():
             context.run_migrations()
 
@@ -40,3 +43,4 @@ if context.is_offline_mode():
     run_migrations_offline()
 else:
     run_migrations_online()
+

--- a/backend/app/db/migrations/versions/797211b68978_create_initial_tables.py
+++ b/backend/app/db/migrations/versions/797211b68978_create_initial_tables.py
@@ -1,0 +1,174 @@
+"""create initial tables
+
+Revision ID: 797211b68978
+Revises: 
+Create Date: 2025-08-08 09:56:20.834503
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy_utils import UUIDType
+
+# revision identifiers, used by Alembic.
+revision = '797211b68978'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+def upgrade() -> None:
+    attack_run_status = sa.Enum(
+        'pending', 'running', 'completed', 'failed', name='attack_run_status'
+    )
+    detection_result_status = sa.Enum(
+        'detected', 'not_detected', 'error', name='detection_result_status'
+    )
+    validation_state = sa.Enum(
+        'pending', 'valid', 'invalid', name='validation_state'
+    )
+    deploy_job_status = sa.Enum(
+        'pending', 'running', 'succeeded', 'failed', name='deploy_job_status'
+    )
+    severity_level = sa.Enum('low', 'medium', 'high', name='severity_level')
+
+    bind = op.get_bind()
+    attack_run_status.create(bind, checkfirst=True)
+    detection_result_status.create(bind, checkfirst=True)
+    validation_state.create(bind, checkfirst=True)
+    deploy_job_status.create(bind, checkfirst=True)
+    severity_level.create(bind, checkfirst=True)
+
+    op.create_table(
+        'rules',
+        sa.Column('id', UUIDType(binary=False), nullable=False),
+        sa.Column('name', sa.String(length=255), nullable=False),
+        sa.Column('description', sa.Text(), nullable=True),
+        sa.Column('is_active', sa.Boolean(), nullable=False, server_default='true'),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('name'),
+    )
+
+    op.create_table(
+        'threat_profile',
+        sa.Column('id', UUIDType(binary=False), nullable=False),
+        sa.Column('name', sa.String(length=255), nullable=False),
+        sa.Column('description', sa.Text(), nullable=True),
+        sa.Column('severity', severity_level, nullable=False, server_default='medium'),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('name'),
+    )
+
+    op.create_table(
+        'customizations',
+        sa.Column('id', UUIDType(binary=False), nullable=False),
+        sa.Column('rule_id', UUIDType(binary=False), nullable=False),
+        sa.Column('data', sa.JSON(), nullable=False),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.PrimaryKeyConstraint('id'),
+        sa.ForeignKeyConstraint(['rule_id'], ['rules.id'], ondelete='CASCADE'),
+    )
+    op.create_index('ix_customizations_rule_id', 'customizations', ['rule_id'])
+
+    op.create_table(
+        'attack_runs',
+        sa.Column('id', UUIDType(binary=False), nullable=False),
+        sa.Column('rule_id', UUIDType(binary=False), nullable=True),
+        sa.Column('threat_profile_id', UUIDType(binary=False), nullable=True),
+        sa.Column('status', attack_run_status, nullable=False, server_default='pending'),
+        sa.Column('started_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('finished_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.PrimaryKeyConstraint('id'),
+        sa.ForeignKeyConstraint(['rule_id'], ['rules.id'], ondelete='SET NULL'),
+        sa.ForeignKeyConstraint(['threat_profile_id'], ['threat_profile.id'], ondelete='SET NULL'),
+    )
+    op.create_index('ix_attack_runs_rule_id', 'attack_runs', ['rule_id'])
+    op.create_index('ix_attack_runs_threat_profile_id', 'attack_runs', ['threat_profile_id'])
+
+    op.create_table(
+        'detection_results',
+        sa.Column('id', UUIDType(binary=False), nullable=False),
+        sa.Column('attack_run_id', UUIDType(binary=False), nullable=False),
+        sa.Column('rule_id', UUIDType(binary=False), nullable=False),
+        sa.Column('status', detection_result_status, nullable=False, server_default='detected'),
+        sa.Column('details', sa.JSON(), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.PrimaryKeyConstraint('id'),
+        sa.ForeignKeyConstraint(['attack_run_id'], ['attack_runs.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['rule_id'], ['rules.id'], ondelete='CASCADE'),
+    )
+    op.create_index('ix_detection_results_attack_run_id', 'detection_results', ['attack_run_id'])
+    op.create_index('ix_detection_results_rule_id', 'detection_results', ['rule_id'])
+
+    op.create_table(
+        'validation_status',
+        sa.Column('id', UUIDType(binary=False), nullable=False),
+        sa.Column('rule_id', UUIDType(binary=False), nullable=False),
+        sa.Column('status', validation_state, nullable=False, server_default='pending'),
+        sa.Column('checked_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.PrimaryKeyConstraint('id'),
+        sa.ForeignKeyConstraint(['rule_id'], ['rules.id'], ondelete='CASCADE'),
+        sa.UniqueConstraint('rule_id'),
+    )
+
+    op.create_table(
+        'deploy_versions',
+        sa.Column('id', UUIDType(binary=False), nullable=False),
+        sa.Column('version', sa.String(length=100), nullable=False),
+        sa.Column('description', sa.Text(), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('version'),
+    )
+
+    op.create_table(
+        'deploy_jobs',
+        sa.Column('id', UUIDType(binary=False), nullable=False),
+        sa.Column('version_id', UUIDType(binary=False), nullable=True),
+        sa.Column('status', deploy_job_status, nullable=False, server_default='pending'),
+        sa.Column('started_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('finished_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.PrimaryKeyConstraint('id'),
+        sa.ForeignKeyConstraint(['version_id'], ['deploy_versions.id'], ondelete='SET NULL'),
+    )
+    op.create_index('ix_deploy_jobs_version_id', 'deploy_jobs', ['version_id'])
+
+def downgrade() -> None:
+    op.drop_index('ix_deploy_jobs_version_id', table_name='deploy_jobs')
+    op.drop_table('deploy_jobs')
+
+    op.drop_table('deploy_versions')
+
+    op.drop_table('validation_status')
+
+    op.drop_index('ix_detection_results_rule_id', table_name='detection_results')
+    op.drop_index('ix_detection_results_attack_run_id', table_name='detection_results')
+    op.drop_table('detection_results')
+
+    op.drop_index('ix_attack_runs_threat_profile_id', table_name='attack_runs')
+    op.drop_index('ix_attack_runs_rule_id', table_name='attack_runs')
+    op.drop_table('attack_runs')
+
+    op.drop_index('ix_customizations_rule_id', table_name='customizations')
+    op.drop_table('customizations')
+
+    op.drop_table('threat_profile')
+
+    op.drop_table('rules')
+
+    sa.Enum(name='deploy_job_status').drop(op.get_bind(), checkfirst=True)
+    sa.Enum(name='validation_state').drop(op.get_bind(), checkfirst=True)
+    sa.Enum(name='detection_result_status').drop(op.get_bind(), checkfirst=True)
+    sa.Enum(name='attack_run_status').drop(op.get_bind(), checkfirst=True)
+    sa.Enum(name='severity_level').drop(op.get_bind(), checkfirst=True)

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -1,0 +1,223 @@
+"""Database models and base metadata."""
+
+from __future__ import annotations
+
+import uuid
+from enum import Enum
+
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    Enum as SqlEnum,
+    ForeignKey,
+    JSON,
+    String,
+    Text,
+)
+from sqlalchemy.orm import declarative_base, relationship
+from sqlalchemy.sql import func
+from sqlalchemy_utils import UUIDType
+
+
+Base = declarative_base()
+
+
+class TimestampMixin:
+    """Mixin providing created/updated timestamps."""
+
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+
+class AttackRunStatus(str, Enum):
+    PENDING = "pending"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+class DetectionResultStatus(str, Enum):
+    DETECTED = "detected"
+    NOT_DETECTED = "not_detected"
+    ERROR = "error"
+
+
+class ValidationState(str, Enum):
+    PENDING = "pending"
+    VALID = "valid"
+    INVALID = "invalid"
+
+
+class DeployJobStatus(str, Enum):
+    PENDING = "pending"
+    RUNNING = "running"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+
+
+class SeverityLevel(str, Enum):
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
+class Rule(TimestampMixin, Base):
+    __tablename__ = "rules"
+
+    id = Column(UUIDType(binary=False), primary_key=True, default=uuid.uuid4)
+    name = Column(String(255), nullable=False, unique=True)
+    description = Column(Text)
+    is_active = Column(Boolean, nullable=False, server_default="true")
+
+    customizations = relationship("Customization", back_populates="rule")
+    attack_runs = relationship("AttackRun", back_populates="rule")
+    detection_results = relationship("DetectionResult", back_populates="rule")
+    validation = relationship("ValidationStatus", uselist=False, back_populates="rule")
+
+
+class Customization(TimestampMixin, Base):
+    __tablename__ = "customizations"
+
+    id = Column(UUIDType(binary=False), primary_key=True, default=uuid.uuid4)
+    rule_id = Column(
+        UUIDType(binary=False),
+        ForeignKey("rules.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    data = Column(JSON, nullable=False)
+
+    rule = relationship("Rule", back_populates="customizations")
+
+
+class ThreatProfile(TimestampMixin, Base):
+    __tablename__ = "threat_profile"
+
+    id = Column(UUIDType(binary=False), primary_key=True, default=uuid.uuid4)
+    name = Column(String(255), nullable=False, unique=True)
+    description = Column(Text)
+    severity = Column(
+        SqlEnum(SeverityLevel, name="severity_level"),
+        nullable=False,
+        server_default=SeverityLevel.MEDIUM.value,
+    )
+
+    attack_runs = relationship("AttackRun", back_populates="threat_profile")
+
+
+class AttackRun(TimestampMixin, Base):
+    __tablename__ = "attack_runs"
+
+    id = Column(UUIDType(binary=False), primary_key=True, default=uuid.uuid4)
+    rule_id = Column(UUIDType(binary=False), ForeignKey("rules.id", ondelete="SET NULL"), index=True)
+    threat_profile_id = Column(
+        UUIDType(binary=False), ForeignKey("threat_profile.id", ondelete="SET NULL"), index=True
+    )
+    status = Column(
+        SqlEnum(AttackRunStatus, name="attack_run_status"),
+        nullable=False,
+        server_default=AttackRunStatus.PENDING.value,
+    )
+    started_at = Column(DateTime(timezone=True))
+    finished_at = Column(DateTime(timezone=True))
+
+    rule = relationship("Rule", back_populates="attack_runs")
+    threat_profile = relationship("ThreatProfile", back_populates="attack_runs")
+    detection_results = relationship("DetectionResult", back_populates="attack_run")
+
+
+class DetectionResult(TimestampMixin, Base):
+    __tablename__ = "detection_results"
+
+    id = Column(UUIDType(binary=False), primary_key=True, default=uuid.uuid4)
+    attack_run_id = Column(
+        UUIDType(binary=False),
+        ForeignKey("attack_runs.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    rule_id = Column(
+        UUIDType(binary=False),
+        ForeignKey("rules.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    status = Column(
+        SqlEnum(DetectionResultStatus, name="detection_result_status"),
+        nullable=False,
+        server_default=DetectionResultStatus.DETECTED.value,
+    )
+    details = Column(JSON)
+
+    attack_run = relationship("AttackRun", back_populates="detection_results")
+    rule = relationship("Rule", back_populates="detection_results")
+
+
+class ValidationStatus(TimestampMixin, Base):
+    __tablename__ = "validation_status"
+
+    id = Column(UUIDType(binary=False), primary_key=True, default=uuid.uuid4)
+    rule_id = Column(
+        UUIDType(binary=False),
+        ForeignKey("rules.id", ondelete="CASCADE"),
+        nullable=False,
+        unique=True,
+    )
+    status = Column(
+        SqlEnum(ValidationState, name="validation_state"),
+        nullable=False,
+        server_default=ValidationState.PENDING.value,
+    )
+    checked_at = Column(DateTime(timezone=True))
+
+    rule = relationship("Rule", back_populates="validation")
+
+
+class DeployVersion(TimestampMixin, Base):
+    __tablename__ = "deploy_versions"
+
+    id = Column(UUIDType(binary=False), primary_key=True, default=uuid.uuid4)
+    version = Column(String(100), nullable=False, unique=True)
+    description = Column(Text)
+
+    deploy_jobs = relationship("DeployJob", back_populates="version")
+
+
+class DeployJob(TimestampMixin, Base):
+    __tablename__ = "deploy_jobs"
+
+    id = Column(UUIDType(binary=False), primary_key=True, default=uuid.uuid4)
+    version_id = Column(
+        UUIDType(binary=False),
+        ForeignKey("deploy_versions.id", ondelete="SET NULL"),
+        index=True,
+    )
+    status = Column(
+        SqlEnum(DeployJobStatus, name="deploy_job_status"),
+        nullable=False,
+        server_default=DeployJobStatus.PENDING.value,
+    )
+    started_at = Column(DateTime(timezone=True))
+    finished_at = Column(DateTime(timezone=True))
+
+    version = relationship("DeployVersion", back_populates="deploy_jobs")
+
+
+__all__ = [
+    "Base",
+    "Rule",
+    "Customization",
+    "AttackRun",
+    "DetectionResult",
+    "ValidationStatus",
+    "DeployJob",
+    "DeployVersion",
+    "ThreatProfile",
+]
+

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -11,6 +11,8 @@ dependencies = [
   "psycopg[binary]>=3.2",
   "alembic>=1.13",
   "python-multipart>=0.0.9",
+  "sqlalchemy-utils>=0.41",   # UUID helper
+  "python-dateutil>=2.9",
 ]
 
 [tool.ruff]


### PR DESCRIPTION
## Summary
- configure Alembic for Postgres and new models
- implement SQLAlchemy models and migration for core entities
- add DB-related dependencies

## Testing
- `pip install -e backend` *(fails: Multiple top-level packages discovered)*
- `pip install sqlalchemy-utils alembic python-dateutil`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895c81dc7f0832db92dda2ebaeb5749