### PR TITLE
Wire routers into FastAPI app and add login helper

### DIFF
--- a/backend/app/api/v1/auth.py
+++ b/backend/app/api/v1/auth.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.security import OAuth2PasswordRequestForm
 from pydantic import BaseModel
-from app.core.security import create_access_token, verify_user_password
+from ...core.security import create_access_token, verify_user_password
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 

--- a/backend/app/db/migrations/env.py
+++ b/backend/app/db/migrations/env.py
@@ -4,7 +4,7 @@ import os
 from alembic import context
 from sqlalchemy import engine_from_config, pool
 
-from app.db.models import Base
+from ..models import Base
 
 
 config = context.config

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -1,7 +1,7 @@
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
-from app.core.config import settings
-from app.db.models import Base  # noqa: F401  # ensure metadata import
+from ..core.config import settings
+from .models import Base  # noqa: F401  # ensure metadata import
 
 engine = create_engine(settings.db_dsn, pool_pre_ping=True, future=True)
 SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False, future=True)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,18 +2,22 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from .core.config import settings
-from .api.v1 import auth, rules
+from .api.v1.auth import router as auth_router
+from .api.v1.rules import router as rules_router
 
-app = FastAPI(title="catchattack-beta API", version="0.1.0")
+app = FastAPI(title="catchattack-beta API", version="0.2.0")
 
 app.add_middleware(
-    CORSMiddleware, allow_origins=settings.cors_origins,
-    allow_credentials=True, allow_methods=["*"], allow_headers=["*"],
+    CORSMiddleware,
+    allow_origins=settings.cors_origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
 )
-
-app.include_router(auth.router, prefix="/api/v1")
-app.include_router(rules.router, prefix="/api/v1")
 
 @app.get("/api/v1/healthz")
 def healthz():
     return {"status": "ok", "env": settings.env}
+
+app.include_router(auth_router, prefix="/api/v1")
+app.include_router(rules_router, prefix="/api/v1")

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3,3 +3,16 @@ export async function ping() {
   const r = await fetch(`${API_BASE}/api/v1/healthz`);
   return r.json();
 }
+
+export async function login(username: string, password: string) {
+  const form = new URLSearchParams();
+  form.set("username", username);
+  form.set("password", password);
+  const r = await fetch(`${API_BASE}/api/v1/auth/token`, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: form,
+  });
+  if (!r.ok) throw new Error("login failed");
+  return r.json();
+}


### PR DESCRIPTION
## Summary
- wire auth and rules routers into FastAPI app and expose health endpoint
- add frontend API helper for logging in
- adjust backend imports to use relative paths and defer Sigma imports

## Testing
- `pytest`
- `curl -s -X POST http://localhost:8000/api/v1/auth/token -H "Content-Type: application/x-www-form-urlencoded" -d "username=admin&password=adminpass" | jq`
- `curl -s -X POST http://localhost:8000/api/v1/rules -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -d @data.json`


------
https://chatgpt.com/codex/tasks/task_e_6895d4a5b58c832d847f87633d0ab6cf