### PR TITLE
Replace deprecated Sigma parser usage

### DIFF
--- a/backend/app/services/sigma_eval/engine.py
+++ b/backend/app/services/sigma_eval/engine.py
@@ -1,9 +1,7 @@
 from typing import Iterable, Dict, Any, List, Tuple
 import ujson as json
 from pathlib import Path
-from sigma.parser.collection import SigmaCollectionParser
-from sigma.backends.elasticsearch import ElasticsearchBackend
-from sigma.exceptions import SigmaError
+import yaml
 from elasticsearch import Elasticsearch, helpers
 
 SUPPORTED_LOCAL_OPS = {"contains", "startswith", "endswith", "equals", "re"}
@@ -56,14 +54,8 @@ def evaluate_local(
     - Only supports a single 'sel' and condition: sel
     - With field ops: contains/startswith/endswith/equals/re via Sigma pipe ops mapping
     """
-    sc = SigmaCollectionParser(sigma_yaml).generate()
-    # Use Elasticsearch backend to get KQL? No—parse AST manually is heavy.
-    # For MVP, expect rules like:
-    # field|contains: "X"
-    # field|re: "regex"
-    # We extract first rule, first selection.
-    rule = sc.rules[0]
-    det = rule.detection
+    data = yaml.safe_load(sigma_yaml)
+    det = data.get("detection", {})
     if "condition" not in det or "sel" not in det:
         # non-supported structure
         return 0, []

--- a/backend/app/services/validation/orchestrator.py
+++ b/backend/app/services/validation/orchestrator.py
@@ -54,10 +54,10 @@ def run_evaluate_elastic(
     results = []
     for rule in rules:
         # Use pySigma backend to produce KQL and wrap in ES DSL query_string
-        from sigma.parser.collection import SigmaCollectionParser
+        from sigma.collection import SigmaCollection
         from sigma.backends.elasticsearch import ElasticsearchBackend
 
-        sc = SigmaCollectionParser(rule.sigma_yaml).generate()
+        sc = SigmaCollection.from_yaml(rule.sigma_yaml)
         backend = ElasticsearchBackend()
         queries = backend.convert(sc)  # list[str]
         total_hits = 0


### PR DESCRIPTION
## Summary
- use pySigma's `SigmaCollection.from_yaml` for elastic evaluations
- parse rule YAML directly in local evaluator and drop `SigmaCollectionParser`

## Testing
- `pytest` *(fails: 404 Client Error: Not Found for url: http://localhost:8000/api/v1/auth/token)*

------
https://chatgpt.com/codex/tasks/task_e_6895e12c2a80832d84436f6436f36f3a