### PR TITLE
Add coverage matrix and technique prioritization services

### DIFF
--- a/backend/app/api/v1/coverage.py
+++ b/backend/app/api/v1/coverage.py
@@ -1,0 +1,39 @@
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.orm import Session
+from typing import List
+from uuid import UUID
+from app.db.session import SessionLocal
+from app.db import models
+from app.db.schemas import CoverageItem, PriorityItem
+from app.services.coverage.matrix import compute_coverage
+from app.services.coverage.prioritizer import prioritize
+from app.core.security import require_role
+
+router = APIRouter(tags=["coverage"])
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@router.get("/coverage", summary="Coverage stats", response_model=List[CoverageItem])
+def get_coverage(
+    collapse_subtechniques: bool = Query(False),
+    db: Session = Depends(get_db),
+    _user=Depends(require_role("admin", "analyst", "viewer")),
+):
+    return compute_coverage(db, collapse_subtechniques)
+
+@router.get("/priorities", summary="Technique priorities", response_model=List[PriorityItem])
+def get_priorities(
+    profile_id: UUID | None = Query(None),
+    collapse_subtechniques: bool = Query(False),
+    db: Session = Depends(get_db),
+    _user=Depends(require_role("admin", "analyst", "viewer")),
+):
+    tp = db.get(models.ThreatProfile, profile_id) if profile_id else None
+    return prioritize(db, tp, collapse_subtechniques)

--- a/backend/app/api/v1/profiles.py
+++ b/backend/app/api/v1/profiles.py
@@ -1,0 +1,46 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+from app.db.session import SessionLocal
+from app.db import models
+from app.db.schemas import ThreatProfilePayload, ThreatProfileOut
+from app.core.security import require_role
+
+router = APIRouter(prefix="/profiles", tags=["profiles"])
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@router.post("", response_model=ThreatProfileOut, summary="Create or update threat profile")
+def create_or_update_profile(
+    payload: ThreatProfilePayload,
+    db: Session = Depends(get_db),
+    _user=Depends(require_role("admin", "analyst")),
+):
+    profile = (
+        db.query(models.ThreatProfile)
+        .filter(models.ThreatProfile.organization == payload.organization)
+        .first()
+    )
+    if profile:
+        profile.industry = payload.industry
+        profile.tech_stack = payload.tech_stack or []
+        profile.intel_tags = payload.intel_tags or []
+        profile.weights = payload.weights
+    else:
+        profile = models.ThreatProfile(
+            organization=payload.organization,
+            industry=payload.industry,
+            tech_stack=payload.tech_stack or [],
+            intel_tags=payload.intel_tags or [],
+            weights=payload.weights,
+        )
+    db.add(profile)
+    db.commit()
+    db.refresh(profile)
+    return profile

--- a/backend/app/db/schemas.py
+++ b/backend/app/db/schemas.py
@@ -35,3 +35,35 @@ class RuleOut(BaseModel):
 
     class Config:
         from_attributes = True
+
+
+class ThreatProfilePayload(BaseModel):
+    organization: str = Field(..., examples=["ACME Corp"])
+    industry: Optional[str] = Field(None, examples=["finance"])
+    tech_stack: List[str] = Field(default_factory=list, examples=[["windows", "linux"]])
+    intel_tags: List[str] = Field(default_factory=list, examples=[["ransomware"]])
+    weights: Optional[dict] = Field(None, examples=[{"T1059": 1.5}])
+
+
+class ThreatProfileOut(ThreatProfilePayload):
+    id: UUID
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class CoverageItem(BaseModel):
+    technique_id: str
+    rules_count: int
+    validated_count: int
+    rule_ids: List[str]
+
+
+class PriorityItem(BaseModel):
+    technique_id: str
+    rules_count: int
+    validated_count: int
+    validated_ratio: float
+    priority_score: float

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,6 +6,8 @@ from .core.config import settings
 from .api.v1.auth import router as auth_router
 from .api.v1.rules import router as rules_router
 from .api.v1.runs import router as runs_router
+from .api.v1.profiles import router as profiles_router
+from .api.v1.coverage import router as coverage_router
 
 os.makedirs(settings.artifacts_dir, exist_ok=True)
 
@@ -26,3 +28,5 @@ def healthz():
 app.include_router(auth_router, prefix="/api/v1")
 app.include_router(rules_router, prefix="/api/v1")
 app.include_router(runs_router, prefix="/api/v1")
+app.include_router(profiles_router, prefix="/api/v1")
+app.include_router(coverage_router, prefix="/api/v1")

--- a/backend/app/services/coverage/__init__.py
+++ b/backend/app/services/coverage/__init__.py
@@ -1,0 +1,1 @@
+"""Coverage calculation and prioritization services."""

--- a/backend/app/services/coverage/matrix.py
+++ b/backend/app/services/coverage/matrix.py
@@ -1,0 +1,47 @@
+from typing import Dict, List
+from sqlalchemy.orm import Session
+from app.db import models
+
+
+def _technique_root(tid: str) -> str:
+    # Collapse subtechniques T1003.001 -> T1003 for matrix aggregation if needed
+    return tid.split(".", 1)[0]
+
+
+def compute_coverage(db: Session, collapse_subtechniques: bool = False) -> List[Dict]:
+    """
+    Returns list of {technique_id, rules_count, validated_count, rule_ids}
+    Collapse sub-techniques if requested.
+    """
+    # Fetch all rules and their validation presence
+    rules = db.query(models.Rule).all()
+    # Build set of validated rule ids
+    validated_rule_ids = set([
+        vs.rule_id
+        for vs in db.query(models.ValidationStatus)
+        .filter(models.ValidationStatus.support > 0)
+        .all()
+    ])
+
+    agg: Dict[str, Dict] = {}
+    for r in rules:
+        if not r.attack_techniques:
+            continue
+        for t in r.attack_techniques:
+            key = _technique_root(t) if collapse_subtechniques else t
+            entry = agg.setdefault(
+                key,
+                {
+                    "technique_id": key,
+                    "rules_count": 0,
+                    "validated_count": 0,
+                    "rule_ids": [],
+                },
+            )
+            entry["rules_count"] += 1
+            entry["rule_ids"].append(str(r.id))
+            if r.id in validated_rule_ids:
+                entry["validated_count"] += 1
+
+    # Sort by technique id for stability
+    return sorted(agg.values(), key=lambda x: x["technique_id"])

--- a/backend/app/services/coverage/prioritizer.py
+++ b/backend/app/services/coverage/prioritizer.py
@@ -1,0 +1,90 @@
+from typing import Dict, List
+from sqlalchemy.orm import Session
+from app.db import models
+from .matrix import compute_coverage
+
+DEFAULT_BASE_WEIGHT = 1.0
+
+
+def _normalize(name: str) -> str:
+    return (name or "").strip().lower()
+
+
+def _weight_from_profile(tp: models.ThreatProfile | None, technique_id: str) -> float:
+    """
+    Heuristics:
+    - Per-technique override in tp.weights: if provided, use it (float)
+    - Boost by simple rules using industry/tech_stack/intel_tags keywords (MVP heuristics)
+    """
+    if not tp:
+        return DEFAULT_BASE_WEIGHT
+
+    # explicit override
+    if tp.weights and technique_id in tp.weights:
+        try:
+            return float(tp.weights[technique_id])
+        except Exception:
+            pass
+
+    boost = 1.0
+    ind = _normalize(tp.industry)
+    stack = set([_normalize(x) for x in (tp.tech_stack or [])])
+    intel = set([_normalize(x) for x in (tp.intel_tags or [])])
+
+    # naive examples — adjust later:
+    if any(k in ind for k in ["finance", "bank"]):
+        # finance cares more about credential access, collection, exfiltration
+        if (
+            technique_id.startswith("T1003")
+            or technique_id.startswith("T1114")
+            or technique_id.startswith("T1041")
+        ):
+            boost *= 1.4
+
+    if "windows" in stack:
+        if technique_id.startswith("T1059"):  # command and scripting
+            boost *= 1.2
+    if "linux" in stack:
+        if technique_id.startswith("T1059"):
+            boost *= 1.1
+
+    if any(k in intel for k in ["ransomware", "initial-access"]):
+        if technique_id.startswith("T1190") or technique_id.startswith("T1566"):
+            # exploit public-facing, phishing
+            boost *= 1.5
+
+    return DEFAULT_BASE_WEIGHT * boost
+
+
+def prioritize(
+    db: Session, tp: models.ThreatProfile | None, collapse_subtechniques: bool = False
+) -> List[Dict]:
+    """
+    priority_score = base_weight * (exposure_weight) * (1 - validated_ratio + gap_bias)
+    Where:
+      - base_weight from profile heuristics or override
+      - exposure_weight approximated by rules_count (more rules -> more activity) but penalize validated coverage
+      - gap_bias gives extra push when there are zero validated rules
+    """
+    cov = compute_coverage(db, collapse_subtechniques)
+    out: List[Dict] = []
+    for item in cov:
+        rules_count = item["rules_count"]
+        validated = item["validated_count"]
+        validated_ratio = (validated / rules_count) if rules_count > 0 else 0.0
+        base_w = _weight_from_profile(tp, item["technique_id"])
+        exposure_w = 1.0 + 0.15 * max(0, rules_count - 1)  # small bump for more content
+        gap_bias = 0.25 if validated == 0 else 0.0
+        score = round(base_w * exposure_w * (1.0 - validated_ratio + gap_bias), 4)
+        out.append(
+            {
+                "technique_id": item["technique_id"],
+                "rules_count": rules_count,
+                "validated_count": validated,
+                "validated_ratio": round(validated_ratio, 4),
+                "priority_score": score,
+            }
+        )
+    # Sort high score first
+    out.sort(key=lambda x: (-x["priority_score"], x["technique_id"]))
+    return out


### PR DESCRIPTION
## Summary
- add coverage matrix and prioritizer services
- expose POST /profiles to manage threat profiles
- expose GET /coverage and GET /priorities endpoints for coverage stats and priority scoring

## Testing
- `pytest tests/backend -q`


------
https://chatgpt.com/codex/tasks/task_e_6895ebb32bf0832dad01cece71d33805