### PR TITLE
Add profiles, coverage, and priorities API endpoints

### DIFF
--- a/backend/app/api/v1/coverage.py
+++ b/backend/app/api/v1/coverage.py
@@ -1,15 +1,13 @@
 from fastapi import APIRouter, Depends, Query
 from sqlalchemy.orm import Session
-from typing import List
-from uuid import UUID
-from app.db.session import SessionLocal
-from app.db import models
-from app.db.schemas import CoverageItem, PriorityItem
-from app.services.coverage.matrix import compute_coverage
-from app.services.coverage.prioritizer import prioritize
-from app.core.security import require_role
+from typing import Optional, List
 
-router = APIRouter(tags=["coverage"])
+from app.db.session import SessionLocal
+from app.core.security import require_role
+from app.services.coverage.matrix import compute_coverage
+
+
+router = APIRouter(prefix="/coverage", tags=["coverage"])
 
 
 def get_db():
@@ -20,20 +18,11 @@ def get_db():
         db.close()
 
 
-@router.get("/coverage", summary="Coverage stats", response_model=List[CoverageItem])
+@router.get("", summary="Get coverage per technique", response_model=List[dict])
 def get_coverage(
     collapse_subtechniques: bool = Query(False),
     db: Session = Depends(get_db),
     _user=Depends(require_role("admin", "analyst", "viewer")),
 ):
-    return compute_coverage(db, collapse_subtechniques)
+    return compute_coverage(db, collapse_subtechniques=collapse_subtechniques)
 
-@router.get("/priorities", summary="Technique priorities", response_model=List[PriorityItem])
-def get_priorities(
-    profile_id: UUID | None = Query(None),
-    collapse_subtechniques: bool = Query(False),
-    db: Session = Depends(get_db),
-    _user=Depends(require_role("admin", "analyst", "viewer")),
-):
-    tp = db.get(models.ThreatProfile, profile_id) if profile_id else None
-    return prioritize(db, tp, collapse_subtechniques)

--- a/backend/app/api/v1/priorities.py
+++ b/backend/app/api/v1/priorities.py
@@ -1,0 +1,37 @@
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.orm import Session
+from typing import Optional, List
+
+from app.db.session import SessionLocal
+from app.db import models
+from app.core.security import require_role
+from app.services.coverage.prioritizer import prioritize
+
+
+router = APIRouter(prefix="/priorities", tags=["priorities"])
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@router.get("", summary="Rank techniques by priority", response_model=List[dict])
+def get_priorities(
+    organization: Optional[str] = Query(None, description="If set, use this org's profile"),
+    collapse_subtechniques: bool = Query(False),
+    db: Session = Depends(get_db),
+    _user=Depends(require_role("admin", "analyst", "viewer")),
+):
+    tp = None
+    if organization:
+        tp = (
+            db.query(models.ThreatProfile)
+            .filter(models.ThreatProfile.organization == organization)
+            .one_or_none()
+        )
+    return prioritize(db, tp, collapse_subtechniques=collapse_subtechniques)
+

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,6 +8,7 @@ from .api.v1.rules import router as rules_router
 from .api.v1.runs import router as runs_router
 from .api.v1.profiles import router as profiles_router
 from .api.v1.coverage import router as coverage_router
+from .api.v1.priorities import router as priorities_router
 
 os.makedirs(settings.artifacts_dir, exist_ok=True)
 
@@ -30,3 +31,4 @@ app.include_router(rules_router, prefix="/api/v1")
 app.include_router(runs_router, prefix="/api/v1")
 app.include_router(profiles_router, prefix="/api/v1")
 app.include_router(coverage_router, prefix="/api/v1")
+app.include_router(priorities_router, prefix="/api/v1")


### PR DESCRIPTION
## Summary
- Add dedicated threat profile management endpoint
- Expose coverage metrics and priority ranking APIs
- Wire new routers into main FastAPI app

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895ee21e20c832da2a7e7bdbd46a359