### PR TITLE
feat: add AI configuration and dependencies

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -18,6 +18,14 @@ class Settings(BaseSettings):
         ]
     )
     artifacts_dir: str = "/app/backend/artifacts"
+
+    # AI
+    ai_provider: str = "local"  # "local"|"openai"|"ollama"
+    ai_model: str = "gpt-4o-mini"  # ignored by local
+    ai_timeout_s: int = 45
+    ai_rate_limit_per_min: int = 10
+    openai_api_key: str | None = None
+    ollama_base_url: str = "http://ollama:11434"
     elastic_url: str = "http://elastic:9200"
     elastic_index_prefix: str = "events"
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,6 +13,7 @@ from .api.v1.tuning import router as tuning_router
 from .api.v1.deploy import router as deploy_router
 
 os.makedirs(settings.artifacts_dir, exist_ok=True)
+os.makedirs(os.path.join(settings.artifacts_dir, "ai_cache"), exist_ok=True)
 
 app = FastAPI(title="catchattack-beta API", version="0.2.0")
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -25,6 +25,9 @@ dependencies = [
   "jsonpatch>=1.33",
   "ruamel.yaml>=0.18",  # preserves YAML mapping order/comments better than PyYAML
   "tenacity>=8.4",
+  "httpx>=0.27",
+  "orjson>=3.10",
+  "jsonschema>=4.23",
 ]
 
 [tool.ruff]


### PR DESCRIPTION
## Summary
- add AI provider config with deterministic defaults and directories for caching
- include httpx, orjson, and jsonschema dependencies for future AI services

## Testing
- `make -f ops/Makefile dev` *(fails: docker: No such file or directory)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896037c7fcc832db5c8a4a61bb57a27