### PR TITLE
feat: add ai service package

### DIFF
--- a/backend/app/services/ai/cache.py
+++ b/backend/app/services/ai/cache.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+import orjson
+from app.core.config import settings
+
+CACHE_DIR = Path(settings.artifacts_dir) / "ai_cache"
+
+
+def cache_get(key: str):
+    p = CACHE_DIR / f"{key}.json"
+    if p.exists():
+        return orjson.loads(p.read_bytes())
+    return None
+
+
+def cache_set(key: str, value: dict):
+    p = CACHE_DIR / f"{key}.json"
+    p.write_bytes(orjson.dumps(value))
+    return True

--- a/backend/app/services/ai/prompts/attack_gen.md
+++ b/backend/app/services/ai/prompts/attack_gen.md
@@ -1,0 +1,13 @@
+You are an adversary emulation engineer. Generate a SAFE, SIMULATED script that demonstrates the requested behaviors without real C2, exfiltration, or destructive actions.
+
+REQUIREMENTS:
+- Output ONLY JSON with keys: script, steps, opsec_notes.
+- The script MUST:
+  - Be in style: {{STYLE}}.
+  - Avoid real network to external hosts; if needed, use placeholders and echo commands.
+  - Include explicit cleanup steps (commented).
+  - Annotate each logical step with comments.
+- No harmful payloads, no credential dumping tools, no disabling security.
+
+INPUT:
+{{INPUT_JSON}}

--- a/backend/app/services/ai/prompts/infra_gen.md
+++ b/backend/app/services/ai/prompts/infra_gen.md
@@ -1,0 +1,12 @@
+You are a lab automation architect. Produce a docker-compose blueprint and provisioning steps.
+
+REQUIREMENTS:
+- Output ONLY JSON with keys: blueprint, assumptions.
+- blueprint.compose_yaml: a minimal working docker-compose.yml as a single YAML string.
+- blueprint.provisioning_steps: ordered list of shell commands to stand up the lab.
+- blueprint.seeds: list of seed data artifacts (filenames + brief descriptions).
+- If telemetry.elastic==true, include Elasticsearch and Kibana and a lightweight shipper (e.g., filebeat with paths).
+- Avoid external dependencies requiring credentials.
+
+INPUT:
+{{INPUT_JSON}}

--- a/backend/app/services/ai/prompts/rule_gen.md
+++ b/backend/app/services/ai/prompts/rule_gen.md
@@ -1,0 +1,10 @@
+You are an expert detection engineer. Produce a Sigma v2 rule modeling the signals and constraints below.
+
+REQUIREMENTS:
+- Output ONLY JSON with keys: sigma_yaml, rationale, test_events.
+- sigma_yaml MUST be valid YAML Sigma v2 with: title, id (uuid4), logsource, detection (selections + condition), fields, falsepositives, level.
+- Prefer concise, broadly portable logic.
+- Include 2-4 synthetic test_events (JSON) that would match the rule.
+
+INPUT:
+{{INPUT_JSON}}

--- a/backend/app/services/ai/provider.py
+++ b/backend/app/services/ai/provider.py
@@ -1,0 +1,73 @@
+from typing import Literal, Dict, Any
+import httpx, os
+from app.core.config import settings
+from .utils import to_json, extract_json_block
+from tenacity import retry, stop_after_attempt, wait_fixed
+
+Provider = Literal["local","openai","ollama"]
+
+
+@retry(stop=stop_after_attempt(2), wait=wait_fixed(1))
+async def _openai_call(prompt: str) -> str:
+    if not settings.openai_api_key:
+        raise RuntimeError("OPENAI_API_KEY missing")
+    headers = {"Authorization": f"Bearer {settings.openai_api_key}"}
+    payload = {
+        "model": settings.ai_model,
+        "messages": [
+            {"role":"system","content":"You MUST respond with JSON only. No prose."},
+            {"role":"user","content": prompt}
+        ],
+        "temperature": 0.2,
+        "max_tokens": 1200,
+    }
+    async with httpx.AsyncClient(timeout=settings.ai_timeout_s) as client:
+        r = await client.post("https://api.openai.com/v1/chat/completions", headers=headers, json=payload)
+        r.raise_for_status()
+        return r.json()["choices"][0]["message"]["content"]
+
+
+@retry(stop=stop_after_attempt(2), wait=wait_fixed(1))
+async def _ollama_call(prompt: str) -> str:
+    url = settings.ollama_base_url.rstrip("/") + "/api/generate"
+    payload = {"model": settings.ai_model, "prompt": prompt, "options": {"temperature": 0.2}}
+    async with httpx.AsyncClient(timeout=settings.ai_timeout_s) as client:
+        r = await client.post(url, json=payload)
+        r.raise_for_status()
+        # streaming or json? Assume full json with "response"
+        data = r.json()
+        return data.get("response") or data  # fallback
+
+
+async def call_provider(provider: Provider, prompt: str) -> Dict[str, Any]:
+    if provider == "openai":
+        txt = await _openai_call(prompt)
+        return extract_json_block(txt)
+    if provider == "ollama":
+        txt = await _ollama_call(prompt)
+        if isinstance(txt, dict): return txt
+        return extract_json_block(txt)
+    # local heuristic mock (deterministic)
+    # Produces minimal viable outputs for tests/offline dev
+    import uuid
+    if '"sigma_yaml"' in prompt:
+        return {
+            "sigma_yaml": f"title: AI Rule\nid: {uuid.uuid4()}\nlogsource: {{ product: windows }}\ndetection:\n  sel:\n    process.command_line|contains: \"-EncodedCommand\"\n  condition: sel\nlevel: medium\n",
+            "rationale":"Heuristic local provider",
+            "test_events":[{"process":{"command_line":"powershell -EncodedCommand AAA"}},{"process":{"command_line":"pwsh -enc BBB"}}]
+        }
+    if '"script"' in prompt or '"steps"' in prompt:
+        return {
+            "script": "# simulated\n echo 'emulation only'\n # cleanup\n echo 'done'",
+            "steps": ["simulate action","cleanup"],
+            "opsec_notes": ["no external network"]
+        }
+    # infra
+    return {
+        "blueprint":{
+            "compose_yaml":"version: '3'\nservices:\n  es:\n    image: docker.elastic.co/elasticsearch/elasticsearch:8.14.1\n    environment:\n      - discovery.type=single-node\n",
+            "provisioning_steps":["docker compose up -d"],
+            "seeds":[{"file":"events.ndjson","desc":"sample events"}]
+        },
+        "assumptions":["local provider defaults"]
+    }

--- a/backend/app/services/ai/safety.py
+++ b/backend/app/services/ai/safety.py
@@ -1,0 +1,19 @@
+import re
+
+DANGEROUS_PATTERNS = [
+    r"Invoke-WebRequest\s+http", r"curl\s+-O\s+http", r"certutil\s+-urlcache",
+    r"powershell\s+-enc", r"nc\s+-e", r"bash\s+-i\s*>&", r"rm\s+-rf\s+/",
+    r"Disable(-| )?(Security|Defender)", r"mimikatz", r"rundll32.+comsvcs"
+]
+
+
+def sanitize_script(script: str) -> tuple[str, list[str]]:
+    notes = []
+    clean = script
+    for pat in DANGEROUS_PATTERNS:
+        if re.search(pat, clean, flags=re.I):
+            clean = re.sub(pat, "# [REMOVED UNSAFE OPERATION]", clean, flags=re.I)
+            notes.append(f"Removed pattern: {pat}")
+    # Block external network destinations; replace with echo placeholders
+    clean = re.sub(r"(curl|wget|Invoke-WebRequest)\s+(\S+)", r'echo "Requested fetch \2 (blocked)"', clean, flags=re.I)
+    return clean, notes

--- a/backend/app/services/ai/schemas.py
+++ b/backend/app/services/ai/schemas.py
@@ -1,0 +1,44 @@
+from pydantic import BaseModel, Field, field_validator
+from typing import List, Dict
+
+
+class RuleGenRequest(BaseModel):
+    signals: Dict
+    constraints: Dict = Field(default_factory=dict)
+
+
+class RuleGenResponse(BaseModel):
+    sigma_yaml: str
+    rationale: str
+    test_events: List[Dict]
+
+
+class AttackGenRequest(BaseModel):
+    goals: List[str]
+    techniques: List[str] = Field(default_factory=list)
+    environment: Dict = Field(default_factory=dict)
+    style: str = "bash"  # bash|powershell|python
+    safety: Dict = Field(default_factory=dict)
+
+
+class AttackGenResponse(BaseModel):
+    script: str
+    steps: List[str]
+    opsec_notes: List[str]
+
+
+class InfraGenRequest(BaseModel):
+    topology: Dict
+    constraints: Dict = Field(default_factory=dict)
+    telemetry: Dict = Field(default_factory=dict)
+
+
+class InfraGenResponse(BaseModel):
+    blueprint: Dict  # {compose_yaml, provisioning_steps[], seeds[]}
+    assumptions: List[str]
+
+    @field_validator("blueprint")
+    def has_compose(cls, v):
+        if "compose_yaml" not in v:
+            raise ValueError("compose_yaml required")
+        return v

--- a/backend/app/services/ai/utils.py
+++ b/backend/app/services/ai/utils.py
@@ -1,0 +1,23 @@
+import orjson
+import hashlib
+
+
+def to_json(obj) -> str:
+    return orjson.dumps(obj, option=orjson.OPT_INDENT_2).decode()
+
+
+def sha256_str(s: str) -> str:
+    return hashlib.sha256(s.encode()).hexdigest()
+
+
+def extract_json_block(text: str) -> dict:
+    # Attempt to parse as pure JSON; if model returns extra text, find first {...} block.
+    try:
+        return orjson.loads(text)
+    except Exception:
+        # naive fallback
+        start = text.find("{")
+        end = text.rfind("}")
+        if start >=0 and end>start:
+            return orjson.loads(text[start:end+1])
+        raise


### PR DESCRIPTION
## Summary
- add AI service package with provider orchestration, caching, prompts, utilities, and safety features
- define strict pydantic schemas for AI interactions

## Testing
- `ruff check backend/app/services/ai` *(fails: E401, F401, E701)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689604db19d8832da9bcb08880d372a4