### PR TITLE
Add demo seeds and script

### DIFF
--- a/ops/Makefile
+++ b/ops/Makefile
@@ -8,6 +8,11 @@ dev:
 	@echo "API -> http://localhost:8000/docs"
 	@echo "WEB -> http://localhost:3000"
 
+demo:
+	$(COMPOSE) up -d --build
+	$(COMPOSE) exec api bash -lc "alembic upgrade head || true"
+	$(COMPOSE) exec api bash -lc "python ops/demo.py"
+
 down:
 	$(COMPOSE) down -v
 

--- a/ops/demo.md
+++ b/ops/demo.md
@@ -1,0 +1,5 @@
+# Demo
+
+`make demo` spins up the stack, seeds rules and telemetry, runs a sample investigation and deploys the generated rules.
+
+Flow: start → ingest → evaluate → deploy.

--- a/ops/demo.py
+++ b/ops/demo.py
@@ -1,0 +1,52 @@
+import requests, json, os, sys
+API=os.getenv("API","http://localhost:8000/api/v1")
+
+def token(u="analyst",p=None):
+    p=p or f"{u}pass"
+    r=requests.post(f"{API}/auth/token", data={"username":u,"password":p}); r.raise_for_status()
+    return r.json()["access_token"]
+
+def create_rule(tok, name, techs, yml, status="active"):
+    r=requests.post(f"{API}/rules", headers={"Authorization":f"Bearer {tok}"}, json={
+        "name":name,"description":"","attack_techniques":techs,"sigma_yaml":yml,"status":status
+    }); r.raise_for_status(); return r.json()["id"]
+
+def main():
+    atok=token("analyst")
+    ah={"Authorization":f"Bearer {atok}"}
+    # seed rules
+    seeds=["pow-enc.yaml","cmd-exec.yaml","reg-runkeys.yaml"]
+    ids=[]
+    for s in seeds:
+        y=open(f"ops/seeds/rules/{s}","r",encoding="utf-8").read()
+        techs={"pow-enc.yaml":["T1059.001"],"cmd-exec.yaml":["T1059"],"reg-runkeys.yaml":["T1547.001"]}[s]
+        rid=create_rule(atok, s.replace(".yaml",""), techs, y, "active")
+        ids.append(rid)
+
+    # profile
+    requests.post(f"{API}/profiles", headers=ah, json={
+        "organization":"AcmeBank","industry":"Finance","tech_stack":["Windows","Elastic"],"intel_tags":["ransomware"],"weights":{"T1059":1.8}
+    }).raise_for_status()
+
+    # run
+    r=requests.post(f"{API}/runs", headers=ah, files={"name":(None,"demo"),"source":(None,"local")}); r.raise_for_status()
+    rid=r.json()["id"]
+    requests.post(f"{API}/runs/{rid}/start", headers=ah).raise_for_status()
+    with open("ops/seeds/telemetry/windows.ndjson","rb") as f:
+        requests.post(f"{API}/runs/{rid}/ingest?auto_index=true", headers=ah, files={"file":("windows.ndjson", f, "application/x-ndjson")}).raise_for_status()
+    ev=requests.post(f"{API}/runs/{rid}/evaluate?engine=local", headers=ah); ev.raise_for_status()
+    print("EVAL:", ev.json())
+
+    # deploy to elastic as admin
+    admtok=token("admin"); adh={"Authorization":f"Bearer {admtok}","Content-Type":"application/json"}
+    payload={"rules":[{"rule_id":r} for r in ids]}
+    dj=requests.post(f"{API}/deploy/elastic", headers=adh, json=payload); dj.raise_for_status()
+    print("DEPLOY JOB:", dj.json())
+
+    # show coverage/priorities
+    cov=requests.get(f"{API}/coverage", headers=ah).json()
+    pri=requests.get(f"{API}/priorities?organization=AcmeBank", headers=ah).json()
+    print("COVERAGE:", cov); print("PRIORITIES:", pri[:3])
+
+if __name__=="__main__":
+    main()

--- a/ops/seeds/attack_scenarios.json
+++ b/ops/seeds/attack_scenarios.json
@@ -1,0 +1,5 @@
+[
+  {"name":"Living off the Land Recon","techniques":["T1059","T1047"]},
+  {"name":"Persistence via Run Keys","techniques":["T1547.001"]},
+  {"name":"Ingress Tool Transfer","techniques":["T1105"]}
+]

--- a/ops/seeds/rules/cmd-exec.yaml
+++ b/ops/seeds/rules/cmd-exec.yaml
@@ -1,0 +1,10 @@
+title: cmd.exe Execution
+id: 22222222-2222-4222-8222-222222222222
+logsource: { product: windows }
+detection:
+  sel:
+    process.command_line|contains: "cmd.exe"
+  condition: sel
+fields: [ host.name, process.command_line ]
+falsepositives: [ "IT scripts" ]
+level: low

--- a/ops/seeds/rules/pow-enc.yaml
+++ b/ops/seeds/rules/pow-enc.yaml
@@ -1,0 +1,10 @@
+title: PowerShell EncodedCommand
+id: 11111111-1111-4111-8111-111111111111
+logsource: { product: windows }
+detection:
+  sel:
+    process.command_line|contains: "-EncodedCommand"
+  condition: sel
+fields: [ host.name, process.command_line ]
+falsepositives: [ "Admin automation" ]
+level: medium

--- a/ops/seeds/rules/reg-runkeys.yaml
+++ b/ops/seeds/rules/reg-runkeys.yaml
@@ -1,0 +1,10 @@
+title: Registry Run Keys Persistence
+id: 33333333-3333-4333-8333-333333333333
+logsource: { product: windows, service: security }
+detection:
+  sel:
+    registry.path|contains: "\\Software\\Microsoft\\Windows\\CurrentVersion\\Run"
+  condition: sel
+fields: [ host.name, registry.path, registry.value ]
+falsepositives: [ "Legit software autostart" ]
+level: medium

--- a/ops/seeds/techniques.json
+++ b/ops/seeds/techniques.json
@@ -1,0 +1,9 @@
+[
+  {"id":"T1059","name":"Command and Scripting Interpreter"},
+  {"id":"T1059.001","name":"PowerShell"},
+  {"id":"T1105","name":"Ingress Tool Transfer"},
+  {"id":"T1003","name":"Credential Dumping"},
+  {"id":"T1112","name":"Modify Registry"},
+  {"id":"T1547.001","name":"Registry Run Keys"},
+  {"id":"T1047","name":"WMI"}
+]

--- a/ops/seeds/telemetry/windows.ndjson
+++ b/ops/seeds/telemetry/windows.ndjson
@@ -1,0 +1,3 @@
+{"@timestamp":"2025-01-01T00:00:00Z","host":{"name":"ws1"},"process":{"command_line":"powershell -EncodedCommand AA=="}} 
+{"@timestamp":"2025-01-01T00:00:10Z","host":{"name":"ws2"},"process":{"command_line":"cmd.exe /c whoami"}}
+{"@timestamp":"2025-01-01T00:00:20Z","host":{"name":"ws3"},"registry":{"path":"HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Run\\Foo","value":"bar"}}


### PR DESCRIPTION
## Summary
- Seed example techniques, attack scenarios, sigma rules, and telemetry
- Add demo script and docs to exercise start→ingest→evaluate→deploy flow
- Expose `make demo` target for one-command demo run

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689610d16618832da8dabe707c8c17b2