### PR TITLE
feat(frontend): add basic dashboard and pages

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,18 +1,44 @@
 export const API_BASE = import.meta.env.VITE_API_BASE ?? "http://localhost:8000";
-export async function ping() {
-  const r = await fetch(`${API_BASE}/api/v1/healthz`);
-  return r.json();
+
+async function j<T>(res: Response): Promise<T> {
+  if (!res.ok) throw new Error(await res.text());
+  return res.json() as Promise<T>;
 }
 
-export async function login(username: string, password: string) {
-  const form = new URLSearchParams();
-  form.set("username", username);
-  form.set("password", password);
-  const r = await fetch(`${API_BASE}/api/v1/auth/token`, {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: form,
-  });
-  if (!r.ok) throw new Error("login failed");
-  return r.json();
+export async function login(username:string,password:string){
+  const form = new URLSearchParams(); form.set("username",username); form.set("password",password);
+  const r = await fetch(`${API_BASE}/api/v1/auth/token`, { method:"POST", headers:{ "Content-Type":"application/x-www-form-urlencoded" }, body: form });
+  return j<{access_token:string,role:string}>(r);
+}
+
+export function withAuth(token:string){ 
+  const h = { "Authorization":`Bearer ${token}", "Content-Type":"application/json" };
+  return {
+    listRules: (technique?:string)=> fetch(`${API_BASE}/api/v1/rules${technique?`?technique=${technique}`:''}`, {headers:h}).then(j),
+    createRule: (body:any)=> fetch(`${API_BASE}/api/v1/rules`, {method:"POST",headers:h,body:JSON.stringify(body)}).then(j),
+    lintRule: (id:string)=> fetch(`${API_BASE}/api/v1/rules/${id}/lint`, {method:"POST",headers:h}).then(j),
+    compileRule: (id:string,target:string)=> fetch(`${API_BASE}/api/v1/rules/${id}/compile?target=${target}`, {method:"POST",headers:h}).then(j),
+    listTuning: (id:string)=> fetch(`${API_BASE}/api/v1/rules/${id}/tuning`, {headers:h}).then(j),
+    addTuning: (id:string, body:any)=> fetch(`${API_BASE}/api/v1/rules/${id}/tuning`, {method:"POST",headers:h,body:JSON.stringify(body)}).then(j),
+    effective: (id:string,target:string, customization_id?:string)=> fetch(`${API_BASE}/api/v1/rules/${id}/effective?target=${target}${customization_id?`&customization_id=${customization_id}`:''}`, {method:"POST",headers:h}).then(j),
+    createRun: (name:string, source:"local"|"atomic"|"caldera")=>{
+      const f = new FormData(); f.set("name",name); f.set("source",source);
+      return fetch(`${API_BASE}/api/v1/runs`, {method:"POST", headers:{ "Authorization":`Bearer ${token}` }, body:f}).then(j);
+    },
+    startRun: (rid:string)=> fetch(`${API_BASE}/api/v1/runs/${rid}/start`, {method:"POST",headers:h}).then(j),
+    ingestRun: (rid:string, file:File, autoIndex:boolean)=> {
+      const f = new FormData(); f.set("file", file);
+      return fetch(`${API_BASE}/api/v1/runs/${rid}/ingest?auto_index=${autoIndex}`, {method:"POST", headers:{ "Authorization":`Bearer ${token}` }, body:f}).then(j);
+    },
+    evaluateRun: (rid:string, engine:"local"|"elastic")=> fetch(`${API_BASE}/api/v1/runs/${rid}/evaluate?engine=${engine}`, {method:"POST",headers:h}).then(j),
+    getRun: (rid:string)=> fetch(`${API_BASE}/api/v1/runs/${rid}`, {headers:h}).then(j),
+    getResults: (rid:string)=> fetch(`${API_BASE}/api/v1/runs/${rid}/results`, {headers:h}).then(j),
+    coverage: ()=> fetch(`${API_BASE}/api/v1/coverage`, {headers:h}).then(j),
+    priorities: (org?:string)=> fetch(`${API_BASE}/api/v1/priorities${org?`?organization=${org}`:''}`, {headers:h}).then(j),
+    deploy: (target:"elastic"|"splunk"|"sentinel", payload:any)=> fetch(`${API_BASE}/api/v1/deploy/${target}`, {method:"POST",headers:h,body:JSON.stringify(payload)}).then(j),
+    job: (jid:string)=> fetch(`${API_BASE}/api/v1/deploy/${jid}`, {headers:h}).then(j),
+    aiRule: (body:any)=> fetch(`${API_BASE}/api/v1/ai/rules/generate`, {method:"POST",headers:h,body:JSON.stringify(body)}).then(j),
+    aiAttack: (body:any)=> fetch(`${API_BASE}/api/v1/ai/attacks/generate`, {method:"POST",headers:h,body:JSON.stringify(body)}).then(j),
+    aiInfra: (body:any)=> fetch(`${API_BASE}/api/v1/ai/infra/generate`, {method:"POST",headers:h,body:JSON.stringify(body)}).then(j)
+  };
 }

--- a/frontend/src/lib/store.ts
+++ b/frontend/src/lib/store.ts
@@ -1,0 +1,3 @@
+export const tokenKey = "catchattack.token";
+export function saveToken(t:string){ localStorage.setItem(tokenKey, t); }
+export function loadToken(){ return localStorage.getItem(tokenKey) || ""; }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,8 +1,45 @@
 import React from "react";
-import ReactDOM from "react-dom/client";
+import {createRoot} from "react-dom/client";
+import Dashboard from "./pages/Dashboard";
+import Coverage from "./pages/Coverage";
+import Rules from "./pages/Rules";
+import RuleDetail from "./pages/RuleDetail";
+import Runs from "./pages/Runs";
+import Deploy from "./pages/Deploy";
+import AIWorkbench from "./pages/AIWorkbench";
 
-ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
-  <React.StrictMode>
-    <div>Hello catchattack-beta</div>
-  </React.StrictMode>
-);
+function Router(){
+  const hash = window.location.hash.slice(2); // e.g. /rules or /rule/<id>
+  if(hash.startsWith("coverage")) return <Coverage/>;
+  if(hash.startsWith("rules")) return <Rules/>;
+  if(hash.startsWith("rule/")) return <RuleDetail id={hash.split("/")[1]}/>;
+  if(hash.startsWith("runs")) return <Runs/>;
+  if(hash.startsWith("deploy")) return <Deploy/>;
+  if(hash.startsWith("ai")) return <AIWorkbench/>;
+  return <Dashboard/>;
+}
+
+function App(){
+  const [tok,setTok]=React.useState(localStorage.getItem("catchattack.token")||"");
+  async function doLogin(role:"admin"|"analyst"|"viewer"){
+    const r = await fetch((import.meta as any).env.VITE_API_BASE+"/api/v1/auth/token",{
+      method:"POST", headers:{ "Content-Type":"application/x-www-form-urlencoded" },
+      body:`username=${role}&password=${role}pass`
+    }); const j = await r.json(); localStorage.setItem("catchattack.token", j.access_token); setTok(j.access_token);
+  }
+  return (
+    <div>
+      <nav className="p-3 flex gap-3 bg-gray-100">
+        <a href="#/">Dashboard</a><a href="#/coverage">Coverage</a><a href="#/rules">Rules</a>
+        <a href="#/runs">Runs</a><a href="#/deploy">Deploy</a><a href="#/ai">AI</a>
+        <span className="ml-auto">
+          <button className="px-2 py-1 border rounded" onClick={()=>doLogin("analyst")}>Login Analyst</button>
+          <button className="px-2 py-1 border rounded ml-2" onClick={()=>doLogin("admin")}>Login Admin</button>
+        </span>
+      </nav>
+      <Router/>
+    </div>
+  );
+}
+
+createRoot(document.getElementById("root")!).render(<App/>);

--- a/frontend/src/pages/AIWorkbench.tsx
+++ b/frontend/src/pages/AIWorkbench.tsx
@@ -1,0 +1,27 @@
+import React,{useState} from "react";
+import { withAuth } from "../lib/api";
+export default function AIWorkbench(){
+  const token=localStorage.getItem("catchattack.token")||""; const api=withAuth(token);
+  const [rule,setRule]=useState<any>(null);
+  const [attack,setAttack]=useState<any>(null);
+  const [infra,setInfra]=useState<any>(null);
+  async function genRule(){
+    const r = await api.aiRule({ signals:{ logs_example:[{ "process.command_line":"powershell -EncodedCommand AA==" }], techniques:["T1059.001"], platform:"windows", siem:"elastic" }, constraints:{ must_explain:true } });
+    setRule(r);
+  }
+  async function genAttack(){ setAttack(await api.aiAttack({ goals:["quiet discovery"], style:"powershell" })); }
+  async function genInfra(){ setInfra(await api.aiInfra({ topology:{ hosts:2, roles:["es","gen"] }, telemetry:{ elastic:true } })); }
+  return (
+    <div className="p-6 space-y-4">
+      <h2 className="text-xl font-semibold">AI Workbench</h2>
+      <div className="space-x-2">
+        <button className="px-2 py-1 border rounded" onClick={genRule}>Generate Sigma</button>
+        <button className="px-2 py-1 border rounded" onClick={genAttack}>Generate Attack (safe)</button>
+        <button className="px-2 py-1 border rounded" onClick={genInfra}>Generate Infra</button>
+      </div>
+      {rule && <><h3 className="font-medium">Sigma</h3><pre className="text-xs bg-gray-50 p-2 rounded">{rule.sigma_yaml}</pre></>}
+      {attack && <><h3 className="font-medium">Attack Script</h3><pre className="text-xs bg-gray-50 p-2 rounded">{attack.script}</pre></>}
+      {infra && <><h3 className="font-medium">Compose</h3><pre className="text-xs bg-gray-50 p-2 rounded">{infra.blueprint.compose_yaml}</pre></>}
+    </div>
+  );
+}

--- a/frontend/src/pages/Coverage.tsx
+++ b/frontend/src/pages/Coverage.tsx
@@ -1,0 +1,22 @@
+import React,{useEffect,useState} from "react";
+import { withAuth } from "../lib/api";
+export default function Coverage(){
+  const token=localStorage.getItem("catchattack.token")||""; const api=withAuth(token);
+  const [rows,setRows]=useState<any[]>([]);
+  useEffect(()=>{ api.coverage().then(setRows); },[]);
+  return (
+    <div className="p-6">
+      <h2 className="text-xl font-semibold mb-4">ATT&CK Coverage</h2>
+      <table className="w-full text-sm">
+        <thead><tr className="text-left border-b"><th>Technique</th><th>Rules</th><th>Validated</th></tr></thead>
+        <tbody>
+        {rows.map(r=>(
+          <tr key={r.technique_id} className="border-b">
+            <td>{r.technique_id}</td><td>{r.rules_count}</td><td>{r.validated_count}</td>
+          </tr>
+        ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,14 +1,21 @@
-import { useEffect, useState } from "react";
-import { ping } from "../lib/api";
-
-export default function Dashboard() {
-  const [status, setStatus] = useState<string>("loading");
-
-  useEffect(() => {
-    ping()
-      .then((data) => setStatus(data.status ?? "unknown"))
-      .catch(() => setStatus("error"));
-  }, []);
-
-  return <div>status: {status}</div>;
+import React, {useEffect,useState} from "react";
+import { withAuth } from "../lib/api";
+export default function Dashboard(){
+  const [data,setData]=useState<any>({}); const token=localStorage.getItem("catchattack.token")||"";
+  const api=withAuth(token);
+  useEffect(()=>{ 
+    Promise.all([api.coverage(), api.priorities("AcmeBank")]).then(([cov,pri])=>{
+      setData({coverage: cov.length, top: pri.slice(0,3)});
+    }).catch(()=>{});
+  },[]);
+  return (
+    <div className="p-6 space-y-4">
+      <h1 className="text-2xl font-bold">catchattack-beta</h1>
+      <div className="grid grid-cols-3 gap-4">
+        <div className="p-4 rounded-xl shadow">Coverage Techniques: <b>{data.coverage ?? 0}</b></div>
+        <div className="p-4 rounded-xl shadow">Top Priorities: <pre className="text-xs">{JSON.stringify(data.top,null,2)}</pre></div>
+        <div className="p-4 rounded-xl shadow">Quick Links: Rules, Runs, Deploy, AI</div>
+      </div>
+    </div>
+  );
 }

--- a/frontend/src/pages/Deploy.tsx
+++ b/frontend/src/pages/Deploy.tsx
@@ -1,0 +1,22 @@
+import React,{useEffect,useState} from "react";
+import { withAuth } from "../lib/api";
+export default function Deploy(){
+  const token=localStorage.getItem("catchattack.token")||""; const api=withAuth(token);
+  const [rules,setRules]=useState<any[]>([]); const [job,setJob]=useState<any>(null);
+  useEffect(()=>{ api.listRules().then(setRules); },[]);
+  async function deploy(target:"elastic"|"splunk"|"sentinel"){
+    const payload={ rules: rules.slice(0,3).map(r=>({rule_id:r.id})) };
+    const j=await api.deploy(target, payload); setJob(j);
+  }
+  return (
+    <div className="p-6 space-y-3">
+      <h2 className="text-xl font-semibold">Deploy</h2>
+      <div className="space-x-2">
+        <button className="px-2 py-1 border rounded" onClick={()=>deploy("elastic")}>Deploy → Elastic</button>
+        <button className="px-2 py-1 border rounded" onClick={()=>deploy("splunk")}>Stub → Splunk</button>
+        <button className="px-2 py-1 border rounded" onClick={()=>deploy("sentinel")}>Stub → Sentinel</button>
+      </div>
+      {job && <pre className="text-xs bg-gray-50 p-2 rounded">{JSON.stringify(job,null,2)}</pre>}
+    </div>
+  );
+}

--- a/frontend/src/pages/RuleDetail.tsx
+++ b/frontend/src/pages/RuleDetail.tsx
@@ -1,0 +1,31 @@
+import React,{useEffect,useState} from "react";
+import { withAuth } from "../lib/api";
+
+export default function RuleDetail({id}:{id:string}){
+  const token=localStorage.getItem("catchattack.token")||""; const api=withAuth(token);
+  const [overlays,setOverlays]=useState<any[]>([]); const [eff,setEff]=useState<any>(null);
+  useEffect(()=>{ api.listTuning(id).then(setOverlays); },[id]);
+  async function addOverlay(){
+    const body={ owner:"ui", notes:"demo exclude host", overlays:[
+      {"op":"add","path":"/detection/fp/host.name|endswith","value":".scanner.local"},
+      {"op":"add","path":"/detection/condition","value":"sel and not fp"}
+    ]};
+    await api.addTuning(id, body); const o=await api.listTuning(id); setOverlays(o);
+  }
+  async function effective(target:string){ const r=await api.effective(id,target); setEff(r); }
+  return (
+    <div className="p-6 space-y-4">
+      <h2 className="text-xl font-semibold">Rule Detail</h2>
+      <div><button className="px-2 py-1 border rounded" onClick={addOverlay}>Add Overlay</button>
+           <button className="px-2 py-1 border rounded ml-2" onClick={()=>effective("elastic")}>Effective→Elastic</button></div>
+      <h3 className="font-medium">Overlays</h3>
+      <pre className="text-xs bg-gray-50 p-2 rounded">{JSON.stringify(overlays,null,2)}</pre>
+      {eff && <>
+        <h3 className="font-medium">Effective YAML</h3>
+        <pre className="text-xs bg-gray-50 p-2 rounded">{eff.effective_yaml}</pre>
+        <h3 className="font-medium">Queries</h3>
+        <pre className="text-xs bg-gray-50 p-2 rounded">{JSON.stringify(eff.queries,null,2)}</pre>
+      </>}
+    </div>
+  );
+}

--- a/frontend/src/pages/Rules.tsx
+++ b/frontend/src/pages/Rules.tsx
@@ -1,0 +1,31 @@
+import React,{useEffect,useState} from "react";
+import { withAuth } from "../lib/api";
+export default function Rules(){
+  const token=localStorage.getItem("catchattack.token")||""; const api=withAuth(token);
+  const [rows,setRows]=useState<any[]>([]); const [msg,setMsg]=useState<string>("");
+  useEffect(()=>{ api.listRules().then(setRows); },[]);
+  async function lint(id:string){ const r=await api.lintRule(id); setMsg(`Lint: ${r.ok}`); }
+  async function compile(id:string, target:string){ const r=await api.compileRule(id,target); setMsg(`Compile ${target}: ${r.ok}`); }
+  return (
+    <div className="p-6 space-y-4">
+      <h2 className="text-xl font-semibold">Rules</h2>
+      {msg && <div className="text-xs text-gray-600">{msg}</div>}
+      <table className="w-full text-sm">
+        <thead><tr className="text-left border-b"><th>Name</th><th>Techniques</th><th>Status</th><th>Actions</th></tr></thead>
+        <tbody>
+        {rows.map(r=>(
+          <tr key={r.id} className="border-b">
+            <td>{r.name}</td><td>{(r.attack_techniques||[]).join(", ")}</td><td>{r.status}</td>
+            <td className="space-x-2">
+              <button className="px-2 py-1 border rounded" onClick={()=>lint(r.id)}>Lint</button>
+              <button className="px-2 py-1 border rounded" onClick={()=>compile(r.id,"elastic")}>Elastic</button>
+              <button className="px-2 py-1 border rounded" onClick={()=>compile(r.id,"sentinel")}>Sentinel</button>
+              <a className="px-2 py-1 underline" href={`#/rule/${r.id}`}>Detail</a>
+            </td>
+          </tr>
+        ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/src/pages/Runs.tsx
+++ b/frontend/src/pages/Runs.tsx
@@ -1,0 +1,21 @@
+import React,{useState} from "react";
+import { withAuth } from "../lib/api";
+
+export default function Runs(){
+  const token=localStorage.getItem("catchattack.token")||""; const api=withAuth(token);
+  const [rid,setRid]=useState<string>(""); const [res,setRes]=useState<any>(null);
+  async function runAll(file?:File){
+    const cr=await api.createRun("ui-run","local"); const id=cr.id; setRid(id);
+    await api.startRun(id);
+    if(file){ await api.ingestRun(id, file, true); }
+    const ev=await api.evaluateRun(id,"local"); setRes(ev);
+  }
+  return (
+    <div className="p-6 space-y-4">
+      <h2 className="text-xl font-semibold">Runs</h2>
+      <input type="file" onChange={(e)=>runAll(e.target.files?.[0]||undefined)} className="block"/>
+      {rid && <div>Run ID: <b>{rid}</b></div>}
+      {res && <pre className="text-xs bg-gray-50 p-2 rounded">{JSON.stringify(res,null,2)}</pre>}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add typed API helper with authenticated endpoints
- implement simple token storage for browser
- build React pages for dashboard, coverage, rules, runs, deploy, and AI workbench with hash routing

## Testing
- `npm test` (fails: No test files found)
- `npm run lint` (fails: 1 error, 17 warnings)


------
https://chatgpt.com/codex/tasks/task_e_6896139214f8832d866cd53e21279845