### PR TITLE
Add pre-commit configuration for Ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.5.4
+    hooks:
+      - id: ruff
+      - id: ruff-format


### PR DESCRIPTION
## Summary
- add pre-commit config using ruff and ruff-format hooks

## Testing
- `pre-commit run --files .pre-commit-config.yaml`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689630e04e9c832d8397538a2a2f3621