### PR TITLE
Add local smoke test script

### DIFF
--- a/ops/smoke.sh
+++ b/ops/smoke.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+API=${API:-http://localhost:8000/api/v1}
+tok(){ curl -s -X POST "$API/auth/token" -d "username=$1&password=${1}pass" | jq -r .access_token; }
+T=$(tok analyst)
+HDR=(-H "Authorization: Bearer $T" -H "Content-Type: application/json")
+# health
+curl -s "$API/healthz" | jq
+# ai local
+curl -s -X POST "${HDR[@]}" "$API/ai/rules/generate" -d '{"signals":{"logs_example":[{"process.command_line":"powershell -EncodedCommand AA=="}],"techniques":["T1059.001"]}}' | jq
+echo "OK"


### PR DESCRIPTION
## Summary
- add ops/smoke.sh for basic health and rule-generation checks against a local API

## Testing
- `PYTHONPATH=backend pytest`
- `npm test` *(fails: Missing script "test")*
- `make coverage` *(fails: No rule to make target 'coverage')*
- `docker compose up -d` *(fails: command not found)*
- `docker compose ps` *(fails: command not found)*
- `bash ops/smoke.sh`

------
https://chatgpt.com/codex/tasks/task_e_689639704628832d97711a0465b5aeb9