### PR TITLE
Fix test imports and refresh docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,7 +94,7 @@ All new features and bug fixes should include tests:
 
 Run tests before submitting a PR:
 ```bash
-npm test
+pytest
 ```
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -235,10 +235,10 @@ npm run lint
 
 ### Testing
 
-Run the test suite:
+Run the backend test suite:
 
 ```bash
-npm test
+pytest
 ```
 
 ### Creating New Components

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -5,40 +5,139 @@ async function j<T>(res: Response): Promise<T> {
   return res.json() as Promise<T>;
 }
 
-export async function login(username:string,password:string){
-  const form = new URLSearchParams(); form.set("username",username); form.set("password",password);
-  const r = await fetch(`${API_BASE}/api/v1/auth/token`, { method:"POST", headers:{ "Content-Type":"application/x-www-form-urlencoded" }, body: form });
-  return j<{access_token:string,role:string}>(r);
+export async function login(username: string, password: string) {
+  const form = new URLSearchParams();
+  form.set("username", username);
+  form.set("password", password);
+  const res = await fetch(`${API_BASE}/api/v1/auth/token`, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: form,
+  });
+  return j<{ access_token: string; role: string }>(res);
 }
 
-export function withAuth(token:string){ 
-  const h = { "Authorization":`Bearer ${token}", "Content-Type":"application/json" };
+export function withAuth(token: string) {
+  const headers = {
+    Authorization: `Bearer ${token}`,
+    "Content-Type": "application/json",
+  };
   return {
-    listRules: (technique?:string)=> fetch(`${API_BASE}/api/v1/rules${technique?`?technique=${technique}`:''}`, {headers:h}).then(j),
-    createRule: (body:any)=> fetch(`${API_BASE}/api/v1/rules`, {method:"POST",headers:h,body:JSON.stringify(body)}).then(j),
-    lintRule: (id:string)=> fetch(`${API_BASE}/api/v1/rules/${id}/lint`, {method:"POST",headers:h}).then(j),
-    compileRule: (id:string,target:string)=> fetch(`${API_BASE}/api/v1/rules/${id}/compile?target=${target}`, {method:"POST",headers:h}).then(j),
-    listTuning: (id:string)=> fetch(`${API_BASE}/api/v1/rules/${id}/tuning`, {headers:h}).then(j),
-    addTuning: (id:string, body:any)=> fetch(`${API_BASE}/api/v1/rules/${id}/tuning`, {method:"POST",headers:h,body:JSON.stringify(body)}).then(j),
-    effective: (id:string,target:string, customization_id?:string)=> fetch(`${API_BASE}/api/v1/rules/${id}/effective?target=${target}${customization_id?`&customization_id=${customization_id}`:''}`, {method:"POST",headers:h}).then(j),
-    createRun: (name:string, source:"local"|"atomic"|"caldera")=>{
-      const f = new FormData(); f.set("name",name); f.set("source",source);
-      return fetch(`${API_BASE}/api/v1/runs`, {method:"POST", headers:{ "Authorization":`Bearer ${token}` }, body:f}).then(j);
+    listRules(technique?: string) {
+      const url = new URL(`${API_BASE}/api/v1/rules`);
+      if (technique) url.searchParams.set("technique", technique);
+      return fetch(url.toString(), { headers }).then(j);
     },
-    startRun: (rid:string)=> fetch(`${API_BASE}/api/v1/runs/${rid}/start`, {method:"POST",headers:h}).then(j),
-    ingestRun: (rid:string, file:File, autoIndex:boolean)=> {
-      const f = new FormData(); f.set("file", file);
-      return fetch(`${API_BASE}/api/v1/runs/${rid}/ingest?auto_index=${autoIndex}`, {method:"POST", headers:{ "Authorization":`Bearer ${token}` }, body:f}).then(j);
+    createRule(body: any) {
+      return fetch(`${API_BASE}/api/v1/rules`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(body),
+      }).then(j);
     },
-    evaluateRun: (rid:string, engine:"local"|"elastic")=> fetch(`${API_BASE}/api/v1/runs/${rid}/evaluate?engine=${engine}`, {method:"POST",headers:h}).then(j),
-    getRun: (rid:string)=> fetch(`${API_BASE}/api/v1/runs/${rid}`, {headers:h}).then(j),
-    getResults: (rid:string)=> fetch(`${API_BASE}/api/v1/runs/${rid}/results`, {headers:h}).then(j),
-    coverage: ()=> fetch(`${API_BASE}/api/v1/coverage`, {headers:h}).then(j),
-    priorities: (org?:string)=> fetch(`${API_BASE}/api/v1/priorities${org?`?organization=${org}`:''}`, {headers:h}).then(j),
-    deploy: (target:"elastic"|"splunk"|"sentinel", payload:any)=> fetch(`${API_BASE}/api/v1/deploy/${target}`, {method:"POST",headers:h,body:JSON.stringify(payload)}).then(j),
-    job: (jid:string)=> fetch(`${API_BASE}/api/v1/deploy/${jid}`, {headers:h}).then(j),
-    aiRule: (body:any)=> fetch(`${API_BASE}/api/v1/ai/rules/generate`, {method:"POST",headers:h,body:JSON.stringify(body)}).then(j),
-    aiAttack: (body:any)=> fetch(`${API_BASE}/api/v1/ai/attacks/generate`, {method:"POST",headers:h,body:JSON.stringify(body)}).then(j),
-    aiInfra: (body:any)=> fetch(`${API_BASE}/api/v1/ai/infra/generate`, {method:"POST",headers:h,body:JSON.stringify(body)}).then(j)
+    lintRule(id: string) {
+      return fetch(`${API_BASE}/api/v1/rules/${id}/lint`, {
+        method: "POST",
+        headers,
+      }).then(j);
+    },
+    compileRule(id: string, target: string) {
+      return fetch(`${API_BASE}/api/v1/rules/${id}/compile?target=${target}`, {
+        method: "POST",
+        headers,
+      }).then(j);
+    },
+    listTuning(id: string) {
+      return fetch(`${API_BASE}/api/v1/rules/${id}/tuning`, { headers }).then(j);
+    },
+    addTuning(id: string, body: any) {
+      return fetch(`${API_BASE}/api/v1/rules/${id}/tuning`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(body),
+      }).then(j);
+    },
+    effective(id: string, target: string, customizationId?: string) {
+      const url = new URL(`${API_BASE}/api/v1/rules/${id}/effective`);
+      url.searchParams.set("target", target);
+      if (customizationId) url.searchParams.set("customization_id", customizationId);
+      return fetch(url.toString(), { method: "POST", headers }).then(j);
+    },
+    createRun(name: string, source: "local" | "atomic" | "caldera") {
+      const form = new FormData();
+      form.set("name", name);
+      form.set("source", source);
+      return fetch(`${API_BASE}/api/v1/runs`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}` },
+        body: form,
+      }).then(j);
+    },
+    startRun(rid: string) {
+      return fetch(`${API_BASE}/api/v1/runs/${rid}/start`, {
+        method: "POST",
+        headers,
+      }).then(j);
+    },
+    ingestRun(rid: string, file: File, autoIndex: boolean) {
+      const form = new FormData();
+      form.set("file", file);
+      return fetch(`${API_BASE}/api/v1/runs/${rid}/ingest?auto_index=${autoIndex}`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}` },
+        body: form,
+      }).then(j);
+    },
+    evaluateRun(rid: string, engine: "local" | "elastic") {
+      return fetch(`${API_BASE}/api/v1/runs/${rid}/evaluate?engine=${engine}`, {
+        method: "POST",
+        headers,
+      }).then(j);
+    },
+    getRun(rid: string) {
+      return fetch(`${API_BASE}/api/v1/runs/${rid}`, { headers }).then(j);
+    },
+    getResults(rid: string) {
+      return fetch(`${API_BASE}/api/v1/runs/${rid}/results`, { headers }).then(j);
+    },
+    coverage() {
+      return fetch(`${API_BASE}/api/v1/coverage`, { headers }).then(j);
+    },
+    priorities(org?: string) {
+      const url = new URL(`${API_BASE}/api/v1/priorities`);
+      if (org) url.searchParams.set("organization", org);
+      return fetch(url.toString(), { headers }).then(j);
+    },
+    deploy(target: "elastic" | "splunk" | "sentinel", payload: any) {
+      return fetch(`${API_BASE}/api/v1/deploy/${target}`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(payload),
+      }).then(j);
+    },
+    job(jid: string) {
+      return fetch(`${API_BASE}/api/v1/deploy/${jid}`, { headers }).then(j);
+    },
+    aiRule(body: any) {
+      return fetch(`${API_BASE}/api/v1/ai/rules/generate`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(body),
+      }).then(j);
+    },
+    aiAttack(body: any) {
+      return fetch(`${API_BASE}/api/v1/ai/attacks/generate`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(body),
+      }).then(j);
+    },
+    aiInfra(body: any) {
+      return fetch(`${API_BASE}/api/v1/ai/infra/generate`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(body),
+      }).then(j);
+    },
   };
 }

--- a/tests/backend/conftest.py
+++ b/tests/backend/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Ensure backend package is on sys.path for tests
+backend_path = Path(__file__).resolve().parents[2] / 'backend'
+if str(backend_path) not in sys.path:
+    sys.path.insert(0, str(backend_path))


### PR DESCRIPTION
## Summary
- ensure backend package is discoverable during tests
- precompile RT script generator prompt
- clean up frontend API helper and doc testing instructions

## Testing
- `pytest`
- `npm run lint` *(fails: ESLint found too many warnings (maximum: 0))*

------
https://chatgpt.com/codex/tasks/task_e_68963b0b1290832d8afe19c7c69c42ba