### PR TITLE
feat: add confidence calculator

### DIFF
--- a/backend/app/services/validation/confidence.py
+++ b/backend/app/services/validation/confidence.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+from datetime import datetime, timezone
+from typing import List, Dict, Any
+from math import exp
+
+
+def _sigmoid(x: float) -> float:
+    return 1.0 / (1.0 + exp(-x))
+
+
+def compute_confidence(
+    *,
+    hits: int,
+    total_events: int,
+    sample_events: List[Dict[str, Any]] | None,
+    last_eval: datetime | None,
+) -> dict:
+    ehr = min(max((hits / total_events) if total_events > 0 else 0.0, 0.0), 1.0)
+    uniq = set()
+    if sample_events:
+        for ev in sample_events:
+            cur = ev
+            for p in ("host", "name"):
+                if isinstance(cur, dict) and p in cur:
+                    cur = cur[p]
+                else:
+                    cur = None
+                    break
+            if isinstance(cur, str):
+                uniq.add(cur)
+    div = min(len(uniq), 5) / 5.0
+    if not last_eval:
+        fresh = 0.0
+    else:
+        days = max((datetime.now(timezone.utc) - last_eval).days, 0)
+        fresh = max(0.0, 1.0 - (days / 30.0))
+    z = 2.0 * ehr + 1.5 * div + 1.0 * fresh
+    conf = round(_sigmoid(z), 4)
+    return {
+        "confidence": conf,
+        "recent_hit_rate": round(ehr, 4),
+        "sample_diversity": round(div, 4),
+        "data_freshness": round(fresh, 4),
+    }


### PR DESCRIPTION
## Summary
- add confidence calculation service using recent hit rate, sample diversity, and data freshness

## Testing
- `pre-commit run --files backend/app/services/validation/confidence.py`
- `pytest`
- `PYTHONPATH=backend python -c "from app.services.validation.confidence import compute_confidence as c; print(c(hits=3,total_events=10,sample_events=[{'host':{'name':'a'}},{'host':{'name':'b'}}],last_eval=None))"`


------
https://chatgpt.com/codex/tasks/task_e_689727f726fc832da8293600a4980bf7