### PR TITLE
Start validation scheduler with API

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -52,3 +52,7 @@ for mod_path in OPTIONAL:
         app.include_router(router, prefix="/api/v1")
     except Exception as e:  # pragma: no cover - optional deps
         logging.warning("Router %s not loaded: %s", mod_path, e)
+
+from .services.validation.scheduler import start_scheduler
+
+_scheduler = start_scheduler()


### PR DESCRIPTION
## Summary
- start validation scheduler during API startup so schedules can trigger after creation

## Testing
- `cd backend && pytest`

------
https://chatgpt.com/codex/tasks/task_e_68973d1a0e74832d8a9b6956acf71e90