### PR TITLE
Add validation schedules API

### DIFF
--- a/backend/app/api/v1/schedules.py
+++ b/backend/app/api/v1/schedules.py
@@ -1,0 +1,92 @@
+from fastapi import APIRouter, Depends, HTTPException, Body
+from typing import List
+from uuid import UUID
+from sqlalchemy.orm import Session
+from app.db.session import SessionLocal
+from app.db import models
+from app.core.security import require_role
+from app.services.validation.scheduler import _execute_schedule
+
+router = APIRouter(prefix="/schedules", tags=["schedules"])
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@router.post("", response_model=dict)
+def create_schedule(
+    payload: dict = Body(...),
+    db: Session = Depends(get_db),
+    _=Depends(require_role("admin","analyst")),
+):
+    row = models.ValidationSchedule(
+        name=payload["name"],
+        cron=payload.get("cron","0 2 * * *"),
+        dataset_uri=payload["dataset_uri"],
+        engine=payload.get("engine","local"),
+        techniques=payload.get("techniques"),
+        rule_ids=payload.get("rule_ids"),
+        auto_index=bool(payload.get("auto_index", False)),
+        enabled=bool(payload.get("enabled", True)),
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return {"id": str(row.id)}
+
+
+@router.get("", response_model=List[dict])
+def list_schedules(
+    db: Session = Depends(get_db),
+    _=Depends(require_role("admin","analyst","viewer")),
+):
+    out = []
+    for s in db.query(models.ValidationSchedule).order_by(models.ValidationSchedule.created_at.desc()).all():
+        out.append({
+            "id": str(s.id),
+            "name": s.name,
+            "cron": s.cron,
+            "dataset_uri": s.dataset_uri,
+            "engine": s.engine,
+            "techniques": s.techniques or [],
+            "enabled": s.enabled,
+            "last_run_at": s.last_run_at,
+        })
+    return out
+
+
+@router.put("/{sid}", response_model=dict)
+def update_schedule(
+    sid: UUID,
+    payload: dict = Body(...),
+    db: Session = Depends(get_db),
+    _=Depends(require_role("admin","analyst")),
+):
+    s = db.get(models.ValidationSchedule, sid)
+    if not s:
+        raise HTTPException(404, "not found")
+    for k in ["name","cron","dataset_uri","engine","techniques","rule_ids","auto_index","enabled"]:
+        if k in payload:
+            setattr(s, k, payload[k])
+    db.add(s)
+    db.commit()
+    db.refresh(s)
+    return {"ok": True}
+
+
+@router.post("/{sid}/run", response_model=dict)
+def run_schedule_now(
+    sid: UUID,
+    db: Session = Depends(get_db),
+    _=Depends(require_role("admin","analyst")),
+):
+    s = db.get(models.ValidationSchedule, sid)
+    if not s:
+        raise HTTPException(404, "not found")
+    _execute_schedule(db, s)
+    return {"ok": True, "last_run_at": s.last_run_at}

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -5,6 +5,7 @@ from sqlalchemy import (
     Enum,
     ForeignKey,
     Integer,
+    Boolean,
     DateTime,
     JSON,
     UniqueConstraint,
@@ -233,3 +234,23 @@ class ThreatProfile(Base, TimestampMixin):
     weights: Mapped[dict | None] = mapped_column(JSON)
 
     __table_args__ = (Index("ix_threat_profile_org", "organization"),)
+
+
+class ValidationSchedule(Base, TimestampMixin):
+    __tablename__ = "validation_schedules"
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    name: Mapped[str] = mapped_column(String(255), unique=True, nullable=False)
+    cron: Mapped[str] = mapped_column(String(255), nullable=False, default="0 2 * * *")
+    dataset_uri: Mapped[str] = mapped_column(String(512), nullable=False)
+    engine: Mapped[str] = mapped_column(String(50), nullable=False, default="local")
+    techniques: Mapped[list[str] | None] = mapped_column(ARRAY(String), default=[])
+    rule_ids: Mapped[list[uuid.UUID] | None] = mapped_column(
+        ARRAY(UUID(as_uuid=True))
+    )
+    auto_index: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    enabled: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    last_run_at: Mapped[DateTime | None] = mapped_column(DateTime(timezone=True))
+
+    __table_args__ = (Index("ix_validation_schedules_enabled", "enabled"),)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,6 +7,7 @@ from importlib import import_module
 from .core.config import settings
 from .api.v1.auth import router as auth_router
 from .api.v1.ai import router as ai_router
+from .api.v1.schedules import router as schedules_router
 from .core.logging import configure, instrument_fastapi
 
 os.makedirs(settings.artifacts_dir, exist_ok=True)
@@ -34,6 +35,7 @@ def readyz():
 
 app.include_router(auth_router, prefix="/api/v1")
 app.include_router(ai_router, prefix="/api/v1")
+app.include_router(schedules_router, prefix="/api/v1")
 
 OPTIONAL = [
     "app.api.v1.rules",


### PR DESCRIPTION
## Summary
- implement CRUD and manual run trigger for validation schedules
- expose schedules routes in FastAPI app
- define `ValidationSchedule` model in database

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'opentelemetry.instrumentation.requests')*

------
https://chatgpt.com/codex/tasks/task_e_68973f214828832db842890a327f2474