### PR TITLE
feat: add rule health metrics API

### DIFF
--- a/backend/app/api/v1/health.py
+++ b/backend/app/api/v1/health.py
@@ -1,0 +1,28 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from uuid import UUID
+from app.db.session import SessionLocal
+from app.db import models
+from app.core.security import require_role
+
+router = APIRouter(prefix="/rules", tags=["health"])
+
+def get_db():
+    db = SessionLocal()
+    try: yield db
+    finally: db.close()
+
+@router.get("/{rule_id}/health", response_model=dict)
+def rule_health(rule_id: UUID, db: Session = Depends(get_db), _=Depends(require_role("admin","analyst","viewer"))):
+    r = db.get(models.Rule, rule_id)
+    if not r: raise HTTPException(404, "Rule not found")
+    vs = db.get(models.ValidationStatus, rule_id)
+    return {
+        "rule_id": str(rule_id),
+        "status": getattr(r.status, "value", r.status),
+        "confidence": getattr(vs, "confidence", None),
+        "recent_hit_rate": getattr(vs, "recent_hit_rate", None),
+        "sample_diversity": getattr(vs, "sample_diversity", None),
+        "data_freshness": getattr(vs, "data_freshness", None),
+        "last_validated_at": getattr(vs, "last_validated_at", None),
+    }

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,6 +8,7 @@ from .core.config import settings
 from .api.v1.auth import router as auth_router
 from .api.v1.ai import router as ai_router
 from .api.v1.schedules import router as schedules_router
+from .api.v1.health import router as rule_health_router
 from .core.logging import configure, instrument_fastapi
 
 os.makedirs(settings.artifacts_dir, exist_ok=True)
@@ -36,6 +37,7 @@ def readyz():
 app.include_router(auth_router, prefix="/api/v1")
 app.include_router(ai_router, prefix="/api/v1")
 app.include_router(schedules_router, prefix="/api/v1")
+app.include_router(rule_health_router, prefix="/api/v1")
 
 OPTIONAL = [
     "app.api.v1.rules",

--- a/tests/backend/test_rule_health_api.py
+++ b/tests/backend/test_rule_health_api.py
@@ -1,0 +1,41 @@
+import requests
+import pytest
+
+BASE = "http://localhost:8000/api/v1"
+
+def _token():
+    try:
+        r = requests.post(
+            f"{BASE}/auth/token",
+            data={"username": "admin", "password": "adminpass"},
+            timeout=2,
+        )
+    except requests.exceptions.ConnectionError:
+        pytest.skip("backend API not reachable on localhost:8000")
+    r.raise_for_status()
+    return r.json()["access_token"]
+
+
+def test_rule_health_endpoint():
+    tok = _token()
+    hdr = {"Authorization": f"Bearer {tok}"}
+
+    sigma = """title: Test Rule\nlogsource: {product: windows}\ndetection:\n  sel:\n    CommandLine|contains: 'cmd.exe'\n  condition: sel\nlevel: low\n"""
+    payload = {
+        "name": "test-rule-health",
+        "description": "desc",
+        "attack_techniques": ["T1059"],
+        "sigma_yaml": sigma,
+        "status": "draft",
+    }
+    r = requests.post(f"{BASE}/rules", headers=hdr, json=payload)
+    r.raise_for_status()
+    rid = r.json()["id"]
+
+    r = requests.get(f"{BASE}/rules/{rid}/health", headers=hdr)
+    r.raise_for_status()
+    data = r.json()
+    assert data["rule_id"] == rid
+    assert "confidence" in data
+
+    requests.delete(f"{BASE}/rules/{rid}", headers=hdr)


### PR DESCRIPTION
## Summary
- expose rule validation health metrics via new `/api/v1/rules/{rule_id}/health` endpoint
- integrate health router into FastAPI app
- test rule health endpoint availability

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689743ecec58832d875dbc7d00a8af79