### PR TITLE
Add Sigma folder import API

### DIFF
--- a/backend/app/api/v1/imports.py
+++ b/backend/app/api/v1/imports.py
@@ -1,0 +1,32 @@
+from fastapi import APIRouter, Depends, Body, HTTPException
+from sqlalchemy.orm import Session
+from app.db.session import SessionLocal
+from app.core.security import require_role
+from app.db import models
+from app.services.imports.folder import import_sigma_folder
+
+router = APIRouter(prefix="/imports", tags=["imports"])
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+@router.post("/folder", response_model=dict, summary="Import Sigma rules from a folder")
+def import_folder(payload: dict = Body(...), db: Session = Depends(get_db), _=Depends(require_role("admin","analyst"))):
+    folder = payload.get("folder")
+    if not folder:
+        raise HTTPException(400, "folder is required (container path)")
+    techs = payload.get("default_techniques") or []
+    res = import_sigma_folder(db, folder, techs)
+    return res
+
+@router.get("/logs", response_model=list[dict], summary="List import logs")
+def list_logs(db: Session = Depends(get_db), _=Depends(require_role("admin","analyst","viewer"))):
+    logs = db.query(models.ImportLog).order_by(models.ImportLog.created_at.desc()).limit(50).all()
+    out=[]
+    for l in logs:
+        out.append({"id": str(l.id), "source": l.source, "uri": l.uri, "total": l.total, "inserted": l.inserted, "deduped": l.deduped, "errors": l.errors, "created_at": l.created_at})
+    return out

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,6 +9,7 @@ from .api.v1.auth import router as auth_router
 from .api.v1.ai import router as ai_router
 from .api.v1.schedules import router as schedules_router
 from .api.v1.health import router as rule_health_router
+from .api.v1.imports import router as imports_router
 from .core.logging import configure, instrument_fastapi
 
 os.makedirs(settings.artifacts_dir, exist_ok=True)
@@ -38,6 +39,7 @@ app.include_router(auth_router, prefix="/api/v1")
 app.include_router(ai_router, prefix="/api/v1")
 app.include_router(schedules_router, prefix="/api/v1")
 app.include_router(rule_health_router, prefix="/api/v1")
+app.include_router(imports_router, prefix="/api/v1")
 
 OPTIONAL = [
     "app.api.v1.rules",


### PR DESCRIPTION
## Summary
- add API endpoints to import Sigma rules from a folder and to list import logs
- wire imports router into FastAPI app

## Testing
- `PYTHONPATH=backend DB_DSN=postgresql+psycopg://postgres:postgres@localhost:5432/catchattack pytest tests/backend/test_healthz.py` *(fails: ModuleNotFoundError: No module named 'opentelemetry.instrumentation.requests')*
- `curl -s -X POST http://localhost:8000/api/v1/imports/folder -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -d '{"folder": "/app/backend/ops/seeds/rules"}'`
- `curl -s -H "Authorization: Bearer $TOKEN" http://localhost:8000/api/v1/imports/logs`

------
https://chatgpt.com/codex/tasks/task_e_68974e7c0d40832d8cc970e7697cbd9e