### PR TITLE
feat: add rule search API

### DIFF
--- a/backend/app/api/v1/search.py
+++ b/backend/app/api/v1/search.py
@@ -1,0 +1,56 @@
+from fastapi import APIRouter, Depends, Query
+from typing import Optional, List
+from sqlalchemy.orm import Session
+from sqlalchemy import or_, func
+
+from ...db.session import SessionLocal
+from ...db import models
+from ...core.security import require_role
+
+router = APIRouter(prefix="/search", tags=["search"])
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@router.get("/rules", response_model=list[dict], summary="Search rules")
+def search_rules(
+    q: Optional[str] = Query(None),
+    technique: Optional[str] = Query(None),
+    status: Optional[str] = Query(None),
+    limit: int = Query(50, ge=1, le=200),
+    db: Session = Depends(get_db),
+    _=Depends(require_role("admin","analyst","viewer"))
+):
+    query = db.query(models.Rule)
+    if q:
+        pat = f"%{q}%"
+        query = query.filter(or_(
+            models.Rule.name.ilike(pat),
+            models.Rule.description.ilike(pat),
+            models.Rule.sigma_yaml.ilike(pat),
+        ))
+    if technique:
+        if db.bind.dialect.name == "postgresql":
+            query = query.filter(models.Rule.attack_techniques.op("&&")([technique]))
+        else:
+            query = query.filter(models.Rule.attack_techniques.any(technique))
+    if status:
+        query = query.filter(models.Rule.status == status)
+    query = query.order_by(models.Rule.updated_at.desc()).limit(limit)
+    rows = query.all()
+    return [
+        {
+            "id": str(r.id),
+            "name": r.name,
+            "status": r.status.value if hasattr(r.status, "value") else r.status,
+            "techniques": r.attack_techniques or [],
+            "updated_at": r.updated_at,
+        }
+        for r in rows
+    ]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -10,6 +10,7 @@ from .api.v1.ai import router as ai_router
 from .api.v1.schedules import router as schedules_router
 from .api.v1.health import router as rule_health_router
 from .api.v1.imports import router as imports_router
+from .api.v1.search import router as search_router
 from .core.logging import configure, instrument_fastapi
 
 os.makedirs(settings.artifacts_dir, exist_ok=True)
@@ -40,6 +41,7 @@ app.include_router(ai_router, prefix="/api/v1")
 app.include_router(schedules_router, prefix="/api/v1")
 app.include_router(rule_health_router, prefix="/api/v1")
 app.include_router(imports_router, prefix="/api/v1")
+app.include_router(search_router, prefix="/api/v1")
 
 OPTIONAL = [
     "app.api.v1.rules",


### PR DESCRIPTION
## Summary
- add rule search endpoint with text, technique, and status filters
- wire search router into main application

## Testing
- `pytest -q`
- `curl -s -H "Authorization: Bearer <token>" "http://127.0.0.1:8000/api/v1/search/rules?q=powershell"`
- `curl -s -H "Authorization: Bearer <token>" "http://127.0.0.1:8000/api/v1/search/rules?technique=T1059.001"`


------
https://chatgpt.com/codex/tasks/task_e_6897514b13d8832d8bf2f5352022994c