### PR TITLE
feat: add builder preview endpoint

### DIFF
--- a/backend/app/api/v1/builder.py
+++ b/backend/app/api/v1/builder.py
@@ -1,11 +1,11 @@
 from fastapi import APIRouter, Depends, Body
-from sqlalchemy.orm import Session
 
 from app.db.session import SessionLocal
 from app.core.security import require_role
-from app.services.builder.models import RuleDraft
+from app.services.builder.models import RuleDraft, PreviewPayload
 from app.services.builder.compile import compile_sigma_from_draft
 from app.services.builder.catalog import operator_catalog
+from app.services.builder.preview import preview_rule
 
 router = APIRouter(prefix="/builder", tags=["builder"])
 
@@ -27,3 +27,10 @@ def get_operators(_=Depends(require_role("admin", "analyst", "viewer"))):
 def compile_draft(payload: RuleDraft = Body(...), _=Depends(require_role("admin", "analyst"))):
     yaml_text = compile_sigma_from_draft(payload)
     return {"sigma_yaml": yaml_text}
+
+
+@router.post("/preview", response_model=dict, summary="Compile draft and preview against dataset")
+def preview_draft(payload: PreviewPayload = Body(...), _=Depends(require_role("admin", "analyst"))):
+    return preview_rule(
+        payload.rule, payload.dataset_uri, payload.inline_events, payload.sample_limit
+    )

--- a/backend/app/services/builder/models.py
+++ b/backend/app/services/builder/models.py
@@ -4,19 +4,21 @@ from typing import List, Literal, Optional, Any, Dict
 
 # Supported operators (MVP)
 Operator = Literal[
-    "equals", "contains", "startswith", "endswith",
-    "in", "regex", "gt", "gte", "lt", "lte"
+    "equals", "contains", "startswith", "endswith", "in", "regex", "gt", "gte", "lt", "lte"
 ]
+
 
 class Predicate(BaseModel):
     field: str
     op: Operator
     value: Any  # string | number | list
 
+
 class LogSource(BaseModel):
     product: Optional[str] = None
     service: Optional[str] = None
     category: Optional[str] = None
+
 
 class RuleDraft(BaseModel):
     title: str = Field(..., min_length=3, max_length=200)
@@ -25,7 +27,14 @@ class RuleDraft(BaseModel):
     technique_ids: List[str] = Field(default_factory=list)  # e.g., ["T1059.001"]
     predicates: List[Predicate] = Field(default_factory=list)
     # combine predicates with 'any' (OR) or 'all' (AND)
-    combine: Literal["any","all"] = "any"
-    level: Literal["low","medium","high","critical"] = "medium"
+    combine: Literal["any", "all"] = "any"
+    level: Literal["low", "medium", "high", "critical"] = "medium"
     falsepositives: List[str] = Field(default_factory=list)
-    fields: List[str] = Field(default_factory=lambda: ["host.name","process.command_line"])
+    fields: List[str] = Field(default_factory=lambda: ["host.name", "process.command_line"])
+
+
+class PreviewPayload(BaseModel):
+    rule: RuleDraft
+    dataset_uri: Optional[str] = None
+    inline_events: Optional[List[Dict[str, Any]]] = None
+    sample_limit: int = 10

--- a/backend/app/services/builder/preview.py
+++ b/backend/app/services/builder/preview.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+from typing import List, Dict, Any, Optional
+from pathlib import Path
+import tempfile
+import os
+import json
+
+from .models import RuleDraft
+from .compile import compile_sigma_from_draft
+
+# We rely on the existing local evaluator:
+# It should return (hits: int, samples: List[Dict])
+try:
+    from app.services.sigma_eval.engine import (
+        evaluate_local,
+    )  # (sigma_yaml: str, ndjson_path: Path) -> tuple[int, list[dict]]
+except Exception:
+    evaluate_local = None  # We'll raise a clean error later
+
+
+def _write_inline_events_to_ndjson(events: List[Dict[str, Any]]) -> str:
+    fd, tmp = tempfile.mkstemp(prefix="builder_preview_", suffix=".ndjson")
+    with os.fdopen(fd, "w", encoding="utf-8") as f:
+        for ev in events:
+            f.write(json.dumps(ev, ensure_ascii=False))
+            f.write("\n")
+    return tmp
+
+
+def _resolve_dataset(
+    dataset_uri: Optional[str], inline_events: Optional[List[Dict[str, Any]]]
+) -> str:
+    if dataset_uri:
+        if not dataset_uri.startswith("file://"):
+            raise ValueError("dataset_uri must start with file:// (NDJSON path)")
+        p = dataset_uri.replace("file://", "")
+        if not Path(p).exists():
+            raise FileNotFoundError(f"dataset not found: {p}")
+        return p
+    if inline_events:
+        return _write_inline_events_to_ndjson(inline_events)
+    raise ValueError("Provide either dataset_uri or inline_events")
+
+
+def preview_rule(
+    draft: RuleDraft,
+    dataset_uri: Optional[str],
+    inline_events: Optional[List[Dict[str, Any]]],
+    sample_limit: int = 10,
+) -> Dict[str, Any]:
+    if evaluate_local is None:
+        raise RuntimeError(
+            "Local Sigma evaluation engine not available (app.services.sigma_eval.engine)"
+        )
+
+    sigma_yaml = compile_sigma_from_draft(draft)
+    path = _resolve_dataset(dataset_uri, inline_events)
+
+    try:
+        hits, samples = evaluate_local(sigma_yaml, Path(path))
+    finally:
+        # cleanup only if we created a temp file (inline_events case)
+        if inline_events and path and path.startswith("/tmp/builder_preview_"):
+            try:
+                os.remove(path)
+            except Exception:
+                pass
+
+    return {
+        "sigma_yaml": sigma_yaml,
+        "hits": int(hits or 0),
+        "samples": (samples or [])[:sample_limit],
+    }


### PR DESCRIPTION
## Summary
- add preview service to compile rule drafts and evaluate on NDJSON datasets
- expose /builder/preview endpoint
- test builder preview with inline events

## Testing
- `pre-commit run --files backend/app/services/builder/preview.py backend/app/services/builder/models.py backend/app/api/v1/builder.py tests/backend/test_builder_api.py`
- `pytest tests/backend`


------
https://chatgpt.com/codex/tasks/task_e_689855bce630832d84563bb9aafb7cf5