### PR TITLE
feat: add NDJSON preview endpoint

### DIFF
--- a/tests/backend/test_builder_api.py
+++ b/tests/backend/test_builder_api.py
@@ -91,7 +91,7 @@ def test_preview_rule_inline_events():
         r = client.post(
             "/api/v1/builder/preview",
             headers=hdr,
-            json={"rule": rule, "inline_events": events},
+            json={"draft": rule, "inline_events": events},
         )
         assert r.status_code == 200
         body = r.json()


### PR DESCRIPTION
## Summary
- add builder endpoint to preview rule drafts using local NDJSON datasets
- adjust builder API tests for new draft-based payload

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689859667ea4832daa90a7916980ca73