### PR TITLE
chore: lint yaml files

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -1,6 +1,7 @@
+---
 name: backend
 
-on:
+'on':
   push:
     paths:
       - 'backend/**'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,10 @@
+# yamllint disable rule:line-length
+---
 name: CI
 
-on:
+'on':
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
 
 jobs:
@@ -14,16 +16,16 @@ jobs:
         env:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: catchattack
-        ports: [ "5432:5432" ]
+        ports: ["5432:5432"]
         options: >-
-          --health-cmd="pg_isready -U postgres" 
+          --health-cmd="pg_isready -U postgres"
           --health-interval=5s --health-timeout=5s --health-retries=10
       elastic:
         image: docker.elastic.co/elasticsearch/elasticsearch:8.14.1
         env:
           discovery.type: single-node
           xpack.security.enabled: "false"
-        ports: [ "9200:9200" ]
+        ports: ["9200:9200"]
         options: >-
           --health-cmd="curl -s http://localhost:9200 >/dev/null || exit 1"
           --health-interval=10s --health-timeout=5s --health-retries=12
@@ -32,7 +34,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v5
-        with: { python-version: "3.11" }
+        with: {python-version: "3.11"}
       - name: Install backend
         run: |
           pip install -U pip
@@ -69,7 +71,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
-        with: { node-version: "20" }
+        with: {node-version: "20"}
       - name: Install & test
         working-directory: frontend
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+---
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.5.4

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,3 +1,5 @@
+# yamllint disable rule:line-length
+---
 version: '3.8'
 services:
   zookeeper:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,3 +1,4 @@
+---
 services:
   db:
     image: postgres:16

--- a/docker/otel-config.yaml
+++ b/docker/otel-config.yaml
@@ -1,3 +1,4 @@
+---
 receivers:
   otlp:
     protocols:

--- a/ops/seeds/rules/cmd-exec.yaml
+++ b/ops/seeds/rules/cmd-exec.yaml
@@ -1,10 +1,15 @@
+---
 title: cmd.exe Execution
 id: 22222222-2222-4222-8222-222222222222
-logsource: { product: windows }
+logsource:
+  product: windows
 detection:
   sel:
     process.command_line|contains: "cmd.exe"
   condition: sel
-fields: [ host.name, process.command_line ]
-falsepositives: [ "IT scripts" ]
+fields:
+  - host.name
+  - process.command_line
+falsepositives:
+  - "IT scripts"
 level: low

--- a/ops/seeds/rules/pow-enc.yaml
+++ b/ops/seeds/rules/pow-enc.yaml
@@ -1,10 +1,15 @@
+---
 title: PowerShell EncodedCommand
 id: 11111111-1111-4111-8111-111111111111
-logsource: { product: windows }
+logsource:
+  product: windows
 detection:
   sel:
     process.command_line|contains: "-EncodedCommand"
   condition: sel
-fields: [ host.name, process.command_line ]
-falsepositives: [ "Admin automation" ]
+fields:
+  - host.name
+  - process.command_line
+falsepositives:
+  - "Admin automation"
 level: medium

--- a/ops/seeds/rules/reg-runkeys.yaml
+++ b/ops/seeds/rules/reg-runkeys.yaml
@@ -1,10 +1,18 @@
+# yamllint disable rule:line-length
+---
 title: Registry Run Keys Persistence
 id: 33333333-3333-4333-8333-333333333333
-logsource: { product: windows, service: security }
+logsource:
+  product: windows
+  service: security
 detection:
   sel:
     registry.path|contains: "\\Software\\Microsoft\\Windows\\CurrentVersion\\Run"
   condition: sel
-fields: [ host.name, registry.path, registry.value ]
-falsepositives: [ "Legit software autostart" ]
+fields:
+  - host.name
+  - registry.path
+  - registry.value
+falsepositives:
+  - "Legit software autostart"
 level: medium


### PR DESCRIPTION
## Summary
- normalize and lint assorted YAML configs

## Testing
- `yamllint docker-compose.dev.yml ops/seeds/rules/cmd-exec.yaml ops/seeds/rules/reg-runkeys.yaml ops/seeds/rules/pow-enc.yaml .github/workflows/backend.yml .github/workflows/ci.yml .pre-commit-config.yaml docker/otel-config.yaml docker/docker-compose.yml`
- `pre-commit run --files .github/workflows/backend.yml .github/workflows/ci.yml .pre-commit-config.yaml docker-compose.dev.yml docker/docker-compose.yml docker/otel-config.yaml ops/seeds/rules/cmd-exec.yaml ops/seeds/rules/pow-enc.yaml ops/seeds/rules/reg-runkeys.yaml`
- `pytest`
- `cd frontend && npm test`
- `pip-audit -r backend/requirements.txt` *(fails: HTTPSConnectionPool(host='pypi.org', port=443): Max retries exceeded with url: /pypi/fastapi/0.116.1/json (Caused by SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Missing Authority Key Identifier (_ssl.c:1028)')))*
- `npm audit`


------
https://chatgpt.com/codex/tasks/task_e_689c76afeca0832d832408b5a2ae5f44